### PR TITLE
Feat/Fix: 공지사항 작성 API 추가 및 댓글/답글 작성 API 오류 수정

### DIFF
--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommentWritePostDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommentWritePostDTO.java
@@ -1,7 +1,5 @@
 package com.jandi.plan_backend.commu.dto;
 
-import com.jandi.plan_backend.commu.entity.Comments;
-import com.jandi.plan_backend.commu.entity.Community;
 import lombok.Data;
 
 /**

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommentWriteRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommentWriteRespDTO.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 @Data
 public class CommentWriteRespDTO {
     private final Integer commentId;
-    private final ParentCommentDTO parentComment;
     private final Integer userId;
     private final LocalDateTime createdAt;
     private final String contents;
@@ -22,6 +21,5 @@ public class CommentWriteRespDTO {
         this.contents = comment.getContents();
         this.likeCount = comment.getLikeCount();
         this.repliesCount = comment.getRepliesCount();
-        this.parentComment = new ParentCommentDTO(comment.getParentComment());
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityWritePostDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityWritePostDTO.java
@@ -2,8 +2,6 @@ package com.jandi.plan_backend.commu.dto;
 
 import lombok.Data;
 
-import java.time.LocalDateTime;
-
 /**
  * 게시글 작성 시 클라이언트로부터 전달되는 데이터를 담는 DTO
  * 게시글 제목과 내용을 저장한다

--- a/src/main/java/com/jandi/plan_backend/commu/repository/CommentRepository.java
+++ b/src/main/java/com/jandi/plan_backend/commu/repository/CommentRepository.java
@@ -4,8 +4,6 @@ import com.jandi.plan_backend.commu.entity.Comments;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommunityService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommunityService.java
@@ -113,6 +113,7 @@ public class CommunityService {
 
         // 댓글 저장
         commentRepository.save(comment);
+        post.setCommentCount(post.getCommentCount() + 1); //게시글의 댓글 수 증가
         if(parentComment != null) { //답글인 경우 상위 댓글의 repliesCount 증가
             parentComment.setRepliesCount(parentComment.getRepliesCount() + 1);
         }

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommunityService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommunityService.java
@@ -121,11 +121,7 @@ public class CommunityService {
         return new CommentWriteRespDTO(comment);
     }
 
-    /**
-     * 검증 검사 메서드
-     *
-     * @return
-     */
+    /** 검증 검사 메서드 */
     // 게시글의 존재 여부 검증
     private Community validatePostExists(Integer postId) {
         return communityRepository.findByPostId(postId)

--- a/src/main/java/com/jandi/plan_backend/resource/controller/NoticeController.java
+++ b/src/main/java/com/jandi/plan_backend/resource/controller/NoticeController.java
@@ -1,8 +1,12 @@
 package com.jandi.plan_backend.resource.controller;
 
 import com.jandi.plan_backend.resource.dto.NoticeListDTO;
+import com.jandi.plan_backend.resource.dto.NoticeWritePostDTO;
+import com.jandi.plan_backend.resource.dto.NoticeWriteRespDTO;
 import com.jandi.plan_backend.resource.service.NoticeService;
+import com.jandi.plan_backend.user.security.JwtTokenProvider;
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -11,9 +15,12 @@ import java.util.Map;
 @RequestMapping("/api/notice")
 public class NoticeController {
     private final NoticeService noticeService;
+    private final JwtTokenProvider jwtTokenProvider; // 추가
 
-    public NoticeController(NoticeService noticeService) {
+
+    public NoticeController(NoticeService noticeService, JwtTokenProvider jwtTokenProvider) {
         this.noticeService = noticeService;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     /**페이지 단위로 공지글 리스트 조회*/
@@ -34,5 +41,23 @@ public class NoticeController {
                 "items", noticePage.getContent()   // 현재 페이지의 게시물 데이터
         );
     }
+
+    /** 공지사항 추가 API */
+    @PostMapping("/write/notice")
+    public ResponseEntity<?> writeNotice(
+            @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
+            @RequestBody NoticeWritePostDTO noticeDTO // JSON 형식으로 공지글 작성 정보 받기
+    ){
+
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        // 공지글 저장 및 반환
+        NoticeWriteRespDTO savedNotice = noticeService.writeNotice(noticeDTO, userEmail);
+        return ResponseEntity.ok(savedNotice);
+    }
+
+
 }
 

--- a/src/main/java/com/jandi/plan_backend/resource/dto/NoticeWritePostDTO.java
+++ b/src/main/java/com/jandi/plan_backend/resource/dto/NoticeWritePostDTO.java
@@ -1,0 +1,14 @@
+package com.jandi.plan_backend.resource.dto;
+
+import lombok.Getter;
+
+/**
+ * 공지사항 작성 시 클라이언트로부터 전달되는 데이터를 담는 DTO
+ * 공지사항 제목과 내용을 저장한다.
+ */
+@Getter
+public class NoticeWritePostDTO {
+    private String title;
+    private String contents;
+
+}

--- a/src/main/java/com/jandi/plan_backend/resource/dto/NoticeWriteRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/resource/dto/NoticeWriteRespDTO.java
@@ -1,0 +1,21 @@
+package com.jandi.plan_backend.resource.dto;
+
+import com.jandi.plan_backend.resource.entity.Notice;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NoticeWriteRespDTO {
+    private final Integer noticeId;
+    private final LocalDateTime createdAt;
+    private final String title;
+    private final String contents;
+
+    public NoticeWriteRespDTO(Notice notice) {
+        this.noticeId = notice.getNoticeId();
+        this.createdAt = notice.getCreatedAt();
+        this.title = notice.getTitle();
+        this.contents = notice.getContents();
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/resource/service/NoticeService.java
+++ b/src/main/java/com/jandi/plan_backend/resource/service/NoticeService.java
@@ -1,23 +1,66 @@
 package com.jandi.plan_backend.resource.service;
 
 import com.jandi.plan_backend.resource.dto.NoticeListDTO;
+import com.jandi.plan_backend.resource.dto.NoticeWritePostDTO;
+import com.jandi.plan_backend.resource.dto.NoticeWriteRespDTO;
+import com.jandi.plan_backend.resource.entity.Notice;
 import com.jandi.plan_backend.resource.repository.NoticeRepository;
+import com.jandi.plan_backend.user.entity.User;
+import com.jandi.plan_backend.user.repository.UserRepository;
+import com.jandi.plan_backend.util.service.BadRequestExceptionMessage;
 import com.jandi.plan_backend.util.service.PaginationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 public class NoticeService {
     private final NoticeRepository noticeRepository;
+    private final UserRepository userRepository;
 
-    public NoticeService(NoticeRepository noticeRepository) {
+
+    public NoticeService(NoticeRepository noticeRepository, UserRepository userRepository) {
         this.noticeRepository = noticeRepository;
+        this.userRepository = userRepository;
     }
 
+    /** 공지글 목록 조회*/
     public Page<NoticeListDTO> getAllNotices(int page, int size) {
         long totalCount = noticeRepository.count();
         return PaginationService.getPagedData(page, size, totalCount, noticeRepository::findAll, NoticeListDTO::new);
     }
+
+    /** 공지글 작성 */
+    public NoticeWriteRespDTO writeNotice(NoticeWritePostDTO noticeDTO, String email) {
+        // 유저 검증
+        User user = validateUserExists(email);
+        validateUserIsAdmin(user);
+
+        // 공지글 생성
+        Notice notice = new Notice();
+        notice.setCreatedAt(LocalDateTime.now());
+        notice.setTitle(noticeDTO.getTitle());
+        notice.setContents(noticeDTO.getContents());
+
+        // DB 저장 및 반환
+        noticeRepository.save(notice);
+        return new NoticeWriteRespDTO(notice);
+    }
+
+    // 사용자의 존재 여부 검증
+    private User validateUserExists(String userEmail) {
+        return userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 사용자입니다."));
+    }
+
+    // 유저가 관리자인지 검증
+    private void validateUserIsAdmin(User user) {
+        if(user.getUserId() != 1)
+            throw new BadRequestExceptionMessage("공지사항을 작성할 권한이 없습니다");
+    }
+
+
 }


### PR DESCRIPTION
## 작업 내용
- 공지사항 작성 API 추가

## 전달 사항
- 댓글 추가 API에서, 널포인터 접근 오류로 400 반환하던 것을 수정
- 댓글/답글 추가 시 빠뜨린 로직 추가 (관련 게시글의 commentCount 증가)