### PR TITLE
Feat: 배너 수정, 공지사항 수정, 배너 삭제, 공지사항 삭제, 댓글 삭제, 게시물 삭제 API 추가

### DIFF
--- a/src/main/java/com/jandi/plan_backend/commu/controller/CommentController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/CommentController.java
@@ -112,4 +112,20 @@ public class CommentController {
         CommentRespDTO updatedPost = commentService.updateComment(commentDTO, commentId, userEmail);
         return ResponseEntity.ok(updatedPost);
     }
+
+    /** 답글 삭제 API */
+    @DeleteMapping("/replies/{replyId}")
+    public ResponseEntity<?> deleteReplies(
+            @PathVariable Integer replyId,
+            @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        // 답글 삭제 및 반환
+        String returnMsg = (commentService.deleteReplies(userEmail, replyId)) ?
+                "삭제되었습니다" : "삭제 과정에서 문제가 발생했습니다. 다시 한번 시도해주세요";
+        return ResponseEntity.ok(returnMsg);
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/controller/CommentController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/CommentController.java
@@ -1,7 +1,10 @@
 package com.jandi.plan_backend.commu.controller;
 
-import com.jandi.plan_backend.commu.dto.*;
-import com.jandi.plan_backend.commu.service.CommunityService;
+import com.jandi.plan_backend.commu.dto.CommentReqDTO;
+import com.jandi.plan_backend.commu.dto.CommentRespDTO;
+import com.jandi.plan_backend.commu.dto.ParentCommentDTO;
+import com.jandi.plan_backend.commu.dto.repliesDTO;
+import com.jandi.plan_backend.commu.service.CommentService;
 import com.jandi.plan_backend.security.JwtTokenProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -11,41 +14,13 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/community")
-public class CommunityController {
-
-    private final CommunityService communityService;
+public class CommentController {
+    private final CommentService commentService;
     private final JwtTokenProvider jwtTokenProvider;
 
-    public CommunityController(CommunityService communityService, JwtTokenProvider jwtTokenProvider) {
-        this.communityService = communityService;
+    public CommentController(CommentService commentService, JwtTokenProvider jwtTokenProvider) {
+        this.commentService = commentService;
         this.jwtTokenProvider = jwtTokenProvider;
-    }
-
-    /** 게시물 목록 조회 API*/
-    @GetMapping("/posts")
-    public Map<String, Object> getPosts(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
-    ){
-        Page<CommunityListDTO> postsPage = communityService.getAllPosts(page, size);
-
-        return Map.of(
-                "pageInfo", Map.of(
-                        "currentPage", postsPage.getNumber(),  // 현재 페이지 번호
-                        "currentSize", postsPage.getContent().size(), //현재 페이지 리스트 갯수
-                        "totalPages", postsPage.getTotalPages(),  // 전체 페이지 번호 개수
-                        "totalSize", postsPage.getTotalElements() // 전체 게시물 리스트 개수
-                ),
-                "items", postsPage.getContent()   // 현재 페이지의 게시물 데이터
-        );
-    }
-
-    /** 특정 게시물 조회 API*/
-    @GetMapping("/posts/{postId}")
-    public Map<String, Object> getPosts(
-            @PathVariable Integer postId //경로 변수로 게시물 고유 번호 받기
-    ){
-        return Map.of("items", communityService.getSpecPost(postId));
     }
 
     /** 댓글 조회 API */
@@ -55,7 +30,7 @@ public class CommunityController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ){
-        Page<ParentCommentDTO> parentCommentsPage = communityService.getAllComments(postId, page, size);
+        Page<ParentCommentDTO> parentCommentsPage = commentService.getAllComments(postId, page, size);
 
         return Map.of(
                 "pageInfo", Map.of(
@@ -75,7 +50,7 @@ public class CommunityController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ){
-        Page<repliesDTO> repliesPage = communityService.getAllReplies(commentId, page, size);
+        Page<repliesDTO> repliesPage = commentService.getAllReplies(commentId, page, size);
 
         return Map.of(
                 "pageInfo", Map.of(
@@ -86,21 +61,6 @@ public class CommunityController {
                 ),
                 "items", repliesPage.getContent()
         );
-    }
-
-    /** 게시글 작성 API */
-    @PostMapping("/posts")
-    public ResponseEntity<?> writePost(
-            @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
-            @RequestBody CommunityReqDTO postDTO // JSON 형식으로 게시글 작성 정보 받기
-    ){
-        // Jwt 토큰으로부터 유저 이메일 추출
-        String jwtToken = token.replace("Bearer ", "");
-        String userEmail = jwtTokenProvider.getEmail(jwtToken);
-
-        // 게시글 저장 및 반환
-        CommunityRespDTO savedPost = communityService.writePost(postDTO, userEmail);
-        return ResponseEntity.ok(savedPost);
     }
 
     /** 댓글 작성 API */
@@ -116,7 +76,7 @@ public class CommunityController {
         String userEmail = jwtTokenProvider.getEmail(jwtToken);
 
         // 댓글 저장 및 반환
-        CommentRespDTO savedComment = communityService.writeComment(commentDTO, postId, userEmail);
+        CommentRespDTO savedComment = commentService.writeComment(commentDTO, postId, userEmail);
         return ResponseEntity.ok(savedComment);
     }
 
@@ -133,24 +93,8 @@ public class CommunityController {
         String userEmail = jwtTokenProvider.getEmail(jwtToken);
 
         // 댓글 저장 및 반환
-        CommentRespDTO savedComment = communityService.writeReplies(commentDTO, commentId, userEmail);
+        CommentRespDTO savedComment = commentService.writeReplies(commentDTO, commentId, userEmail);
         return ResponseEntity.ok(savedComment);
-    }
-
-    /** 게시물 수정 API */
-    @PatchMapping("/posts/{postId}")
-    public ResponseEntity<?> updatePost(
-            @PathVariable Integer postId, //경로 변수로 변경할 게시글 아이디 받기
-            @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
-            @RequestBody CommunityReqDTO postDTO // JSON 형식으로 게시글 작성 정보 받기
-    ){
-        // Jwt 토큰으로부터 유저 이메일 추출
-        String jwtToken = token.replace("Bearer ", "");
-        String userEmail = jwtTokenProvider.getEmail(jwtToken);
-
-        // 게시물 수정 및 반환
-        CommunityRespDTO updatedPost = communityService.updatePost(postDTO, postId, userEmail);
-        return ResponseEntity.ok(updatedPost);
     }
 
     /** 댓글 및 답글 수정 API */
@@ -165,7 +109,7 @@ public class CommunityController {
         String userEmail = jwtTokenProvider.getEmail(jwtToken);
 
         // 게시물 수정 및 반환
-        CommentRespDTO updatedPost = communityService.updateComment(commentDTO, commentId, userEmail);
+        CommentRespDTO updatedPost = commentService.updateComment(commentDTO, commentId, userEmail);
         return ResponseEntity.ok(updatedPost);
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/controller/CommentController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/CommentController.java
@@ -113,10 +113,10 @@ public class CommentController {
         return ResponseEntity.ok(updatedPost);
     }
 
-    /** 답글 삭제 API */
-    @DeleteMapping("/replies/{replyId}")
+    /** 댓글 및 답글 삭제 API */
+    @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<?> deleteReplies(
-            @PathVariable Integer replyId,
+            @PathVariable Integer commentId,
             @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
     ){
         // Jwt 토큰으로부터 유저 이메일 추출
@@ -124,8 +124,9 @@ public class CommentController {
         String userEmail = jwtTokenProvider.getEmail(jwtToken);
 
         // 답글 삭제 및 반환
-        String returnMsg = (commentService.deleteReplies(userEmail, replyId)) ?
-                "삭제되었습니다" : "삭제 과정에서 문제가 발생했습니다. 다시 한번 시도해주세요";
+        int deletedRepliesCount = (commentService.deleteComments(userEmail, commentId));
+        String returnMsg = (deletedRepliesCount == 0) ?
+                "답글이 삭제되었습니다": "선택된 댓글과 하위 답글 " + deletedRepliesCount +"개가 삭제되었습니다";
         return ResponseEntity.ok(returnMsg);
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/controller/PostController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/PostController.java
@@ -1,0 +1,82 @@
+package com.jandi.plan_backend.commu.controller;
+
+import com.jandi.plan_backend.commu.dto.*;
+import com.jandi.plan_backend.commu.service.PostService;
+import com.jandi.plan_backend.security.JwtTokenProvider;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/community")
+public class PostController {
+
+    private final PostService communityService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public PostController(PostService postService, JwtTokenProvider jwtTokenProvider) {
+        this.communityService = postService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    /** 게시물 목록 조회 API*/
+    @GetMapping("/posts")
+    public Map<String, Object> getPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        Page<CommunityListDTO> postsPage = communityService.getAllPosts(page, size);
+
+        return Map.of(
+                "pageInfo", Map.of(
+                        "currentPage", postsPage.getNumber(),  // 현재 페이지 번호
+                        "currentSize", postsPage.getContent().size(), //현재 페이지 리스트 갯수
+                        "totalPages", postsPage.getTotalPages(),  // 전체 페이지 번호 개수
+                        "totalSize", postsPage.getTotalElements() // 전체 게시물 리스트 개수
+                ),
+                "items", postsPage.getContent()   // 현재 페이지의 게시물 데이터
+        );
+    }
+
+    /** 특정 게시물 조회 API*/
+    @GetMapping("/posts/{postId}")
+    public Map<String, Object> getPosts(
+            @PathVariable Integer postId //경로 변수로 게시물 고유 번호 받기
+    ){
+        return Map.of("items", communityService.getSpecPost(postId));
+    }
+
+    /** 게시글 작성 API */
+    @PostMapping("/posts")
+    public ResponseEntity<?> writePost(
+            @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
+            @RequestBody CommunityReqDTO postDTO // JSON 형식으로 게시글 작성 정보 받기
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        // 게시글 저장 및 반환
+        CommunityRespDTO savedPost = communityService.writePost(postDTO, userEmail);
+        return ResponseEntity.ok(savedPost);
+    }
+
+    /** 게시물 수정 API */
+    @PatchMapping("/posts/{postId}")
+    public ResponseEntity<?> updatePost(
+            @PathVariable Integer postId, //경로 변수로 변경할 게시글 아이디 받기
+            @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
+            @RequestBody CommunityReqDTO postDTO // JSON 형식으로 게시글 작성 정보 받기
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        // 게시물 수정 및 반환
+        CommunityRespDTO updatedPost = communityService.updatePost(postDTO, postId, userEmail);
+        return ResponseEntity.ok(updatedPost);
+    }
+
+}

--- a/src/main/java/com/jandi/plan_backend/commu/controller/PostController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/PostController.java
@@ -79,4 +79,21 @@ public class PostController {
         return ResponseEntity.ok(updatedPost);
     }
 
+    /** 게시물 삭제 API */
+    @DeleteMapping("/posts/{postId}")
+    public ResponseEntity<?> deletePost(
+            @PathVariable Integer postId,
+            @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        // 게시물 삭제 및 반환
+        int deleteCommentCount = communityService.deletePost(postId, userEmail);
+        String returnMsg = (deleteCommentCount == 0) ?
+                "게시물이 삭제되었습니다": "선택된 게시물과 하위 댓글 " + deleteCommentCount +"개가 삭제되었습니다";
+        return ResponseEntity.ok(returnMsg);
+    }
+
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommentReqDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommentReqDTO.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.dto;
 
 import lombok.Data;
+import lombok.NonNull;
 
 /**
  * 댓글 작성 시 클라이언트로부터 전달되는 데이터를 담는 DTO
@@ -8,5 +9,5 @@ import lombok.Data;
  */
 @Data
 public class CommentReqDTO {
-    private String contents;
+    @NonNull  String contents;
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityItemDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityItemDTO.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.commu.entity.Community;
+import com.jandi.plan_backend.storage.service.ImageService;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -19,13 +20,14 @@ public class CommunityItemDTO {
     private final Integer likeCount;
     private final Integer commentCount;
 
-    public CommunityItemDTO(Community community) {
+    public CommunityItemDTO(Community community, ImageService imageService) {
         this.postId = community.getPostId();
-        this.user = new UserCommunityDTO(community.getUser()); // UserDTO를 사용
+        this.user = new UserCommunityDTO(community.getUser(), imageService);
         this.createdAt = community.getCreatedAt();
         this.title = community.getTitle();
         this.content = community.getContents();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
     }
+
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.commu.entity.Community;
+import com.jandi.plan_backend.storage.service.ImageService;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -18,12 +19,13 @@ public class CommunityListDTO {
     private final Integer likeCount;
     private final Integer commentCount;
 
-    public CommunityListDTO(Community community) {
+    public CommunityListDTO(Community community, ImageService imageService) {
         this.postId = community.getPostId();
-        this.user = new UserCommunityDTO(community.getUser()); // UserDTO를 사용
+        this.user = new UserCommunityDTO(community.getUser(), imageService);
         this.createdAt = community.getCreatedAt();
         this.title = community.getTitle();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
     }
+
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReqDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReqDTO.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.dto;
 
 import lombok.Data;
+import lombok.NonNull;
 
 /**
  * 게시글 작성 시 클라이언트로부터 전달되는 데이터를 담는 DTO
@@ -8,6 +9,6 @@ import lombok.Data;
  */
 @Data
 public class CommunityReqDTO {
-    private final String title;
-    private final String content;
+    @NonNull final String title;
+    @NonNull private final String content;
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityRespDTO.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.commu.entity.Community;
+import com.jandi.plan_backend.storage.service.ImageService;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -19,13 +20,13 @@ public class CommunityRespDTO {
     private int commentCount;
     private UserCommunityDTO user; // 유저 정보 중 민감 정보 제외
 
-    public CommunityRespDTO(Community community) {
+    public CommunityRespDTO(Community community, ImageService imageService) {
         this.postId = community.getPostId();
+        this.user = new UserCommunityDTO(community.getUser(), imageService);
+        this.createdAt = community.getCreatedAt();
         this.title = community.getTitle();
         this.content = community.getContents();
-        this.createdAt = community.getCreatedAt();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
-        this.user = new UserCommunityDTO(community.getUser());
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/ParentCommentDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/ParentCommentDTO.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.commu.entity.Comments;
+import com.jandi.plan_backend.storage.service.ImageService;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -9,14 +10,16 @@ import java.time.LocalDateTime;
 public class ParentCommentDTO {
     private final Integer commentId;
     private final Integer userId;
+    private final String profileImageUrl;
     private final LocalDateTime createdAt;
     private final String contents;
     private final Integer likeCount;
     private final Integer repliesCount; //답글 수
 
-    public ParentCommentDTO(Comments comment) {
+    public ParentCommentDTO(Comments comment, ImageService imageService) {
         this.commentId = comment.getCommentId();
         this.userId = comment.getUserId();
+        this.profileImageUrl = imageService.getUserProfile(userId);
         this.createdAt = comment.getCreatedAt();
         this.contents = comment.getContents();
         this.likeCount = comment.getLikeCount();

--- a/src/main/java/com/jandi/plan_backend/commu/dto/ParentCommentDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/ParentCommentDTO.java
@@ -2,6 +2,8 @@ package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.commu.entity.Comments;
 import com.jandi.plan_backend.storage.service.ImageService;
+import com.jandi.plan_backend.user.entity.User;
+import com.jandi.plan_backend.user.repository.UserRepository;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -9,17 +11,15 @@ import java.time.LocalDateTime;
 @Getter
 public class ParentCommentDTO {
     private final Integer commentId;
-    private final Integer userId;
-    private final String profileImageUrl;
+    private final UserCommunityDTO user;
     private final LocalDateTime createdAt;
     private final String contents;
     private final Integer likeCount;
     private final Integer repliesCount; //답글 수
 
-    public ParentCommentDTO(Comments comment, ImageService imageService) {
+    public ParentCommentDTO(Comments comment, User user, ImageService imageService) {
         this.commentId = comment.getCommentId();
-        this.userId = comment.getUserId();
-        this.profileImageUrl = imageService.getUserProfile(userId);
+        this.user = new UserCommunityDTO(user, imageService) ;
         this.createdAt = comment.getCreatedAt();
         this.contents = comment.getContents();
         this.likeCount = comment.getLikeCount();

--- a/src/main/java/com/jandi/plan_backend/commu/dto/UserCommunityDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/UserCommunityDTO.java
@@ -1,5 +1,6 @@
 package com.jandi.plan_backend.commu.dto;
 
+import com.jandi.plan_backend.storage.service.ImageService;
 import com.jandi.plan_backend.user.entity.User;
 import lombok.Getter;
 
@@ -14,12 +15,14 @@ public class UserCommunityDTO {
     private final String firstName;  // 사용자 이름
     private final String lastName;   // 사용자 성
     private final String email;
+    private final String profileImageUrl;
 
-    public UserCommunityDTO(User user) {
+    public UserCommunityDTO(User user, ImageService imageService) {
         this.userId = user.getUserId();
         this.userName = user.getUserName();
         this.firstName = user.getFirstName();
         this.lastName = user.getLastName();
         this.email = user.getEmail();
+        this.profileImageUrl = imageService.getUserProfile(user.getUserId());
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/UserCommunityDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/UserCommunityDTO.java
@@ -1,7 +1,9 @@
 package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.storage.service.ImageService;
+import com.jandi.plan_backend.user.dto.UserRegisterDTO;
 import com.jandi.plan_backend.user.entity.User;
+import com.jandi.plan_backend.user.repository.UserRepository;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/jandi/plan_backend/commu/dto/repliesDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/repliesDTO.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.commu.entity.Comments;
+import com.jandi.plan_backend.storage.service.ImageService;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -9,13 +10,15 @@ import java.time.LocalDateTime;
 public class repliesDTO {
     private final Integer commentId;
     private final Integer userId;
+    private final String profileImageUrl;
     private final LocalDateTime createdAt;
     private final String contents;
     private final Integer likeCount;
 
-    public repliesDTO(Comments comment) {
+    public repliesDTO(Comments comment, ImageService imageService) {
         this.commentId = comment.getCommentId();
         this.userId = comment.getUserId();
+        this.profileImageUrl = imageService.getUserProfile(userId);
         this.createdAt = comment.getCreatedAt();
         this.contents = comment.getContents();
         this.likeCount = comment.getLikeCount();

--- a/src/main/java/com/jandi/plan_backend/commu/dto/repliesDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/repliesDTO.java
@@ -2,6 +2,7 @@ package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.commu.entity.Comments;
 import com.jandi.plan_backend.storage.service.ImageService;
+import com.jandi.plan_backend.user.entity.User;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -9,16 +10,16 @@ import java.time.LocalDateTime;
 @Getter
 public class repliesDTO {
     private final Integer commentId;
-    private final Integer userId;
-    private final String profileImageUrl;
+    private final Integer parentCommentId;
     private final LocalDateTime createdAt;
     private final String contents;
     private final Integer likeCount;
+    private final UserCommunityDTO user;
 
-    public repliesDTO(Comments comment, ImageService imageService) {
+    public repliesDTO(Comments comment, User user, ImageService imageService) {
         this.commentId = comment.getCommentId();
-        this.userId = comment.getUserId();
-        this.profileImageUrl = imageService.getUserProfile(userId);
+        this.parentCommentId = getParentCommentId();
+        this.user = new UserCommunityDTO(user, imageService);
         this.createdAt = comment.getCreatedAt();
         this.contents = comment.getContents();
         this.likeCount = comment.getLikeCount();

--- a/src/main/java/com/jandi/plan_backend/commu/repository/CommentRepository.java
+++ b/src/main/java/com/jandi/plan_backend/commu/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.repository;
 
 import com.jandi.plan_backend.commu.entity.Comments;
+import com.jandi.plan_backend.commu.entity.Community;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,4 +28,6 @@ public interface CommentRepository extends JpaRepository<Comments, Integer> {
 
     //특정 댓글에 속한 자식 답글을 모두 조회하는 메서드
     List<Comments> findByParentCommentCommentId(Integer commentId);
+
+    List<Comments> findByCommunity(Community community);
 }

--- a/src/main/java/com/jandi/plan_backend/commu/repository/CommentRepository.java
+++ b/src/main/java/com/jandi/plan_backend/commu/repository/CommentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comments, Integer> {
@@ -23,4 +24,7 @@ public interface CommentRepository extends JpaRepository<Comments, Integer> {
 
     //댓글이 존재하는지 조회하는 메서드
     Optional<Object> findByCommentId(Integer commentId);
+
+    //특정 댓글에 속한 자식 답글을 모두 조회하는 메서드
+    List<Comments> findByParentCommentCommentId(Integer commentId);
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
@@ -134,7 +134,7 @@ public class CommentService {
         // 유저 검증
         User user = validationUtil.validateUserExists(userEmail);
         validationUtil.validateUserRestricted(user);
-        validationUtil.validateUserIsAuthorOfComment(user, comment);
+        if(user.getUserId()!=1) validationUtil.validateUserIsAuthorOfComment(user, comment);
 
         // 만약 댓글일 경우 하위 답글 모두 삭제
         int repliesCount = 0;

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
@@ -1,49 +1,33 @@
 package com.jandi.plan_backend.commu.service;
 
-import com.jandi.plan_backend.commu.dto.*;
+import com.jandi.plan_backend.commu.dto.CommentReqDTO;
+import com.jandi.plan_backend.commu.dto.CommentRespDTO;
+import com.jandi.plan_backend.commu.dto.ParentCommentDTO;
+import com.jandi.plan_backend.commu.dto.repliesDTO;
 import com.jandi.plan_backend.commu.entity.Comments;
 import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.commu.repository.CommentRepository;
 import com.jandi.plan_backend.commu.repository.CommunityRepository;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.util.ValidationUtil;
+import com.jandi.plan_backend.util.service.PaginationService;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
-import com.jandi.plan_backend.util.service.PaginationService;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Service
-public class CommunityService {
-
+public class CommentService {
     private final CommunityRepository communityRepository;
     private final CommentRepository commentRepository;
     private final ValidationUtil validationUtil;
 
     // 생성자를 통해 필요한 의존성들을 주입받음.
-    public CommunityService(CommunityRepository communityRepository, CommentRepository commentRepository, ValidationUtil validationUtil) {
+    public CommentService(CommunityRepository communityRepository, CommentRepository commentRepository, ValidationUtil validationUtil) {
         this.communityRepository = communityRepository;
         this.commentRepository = commentRepository;
         this.validationUtil = validationUtil;
     }
-
-    /** 특정 게시글 조회 */
-    public Optional<CommunityItemDTO> getSpecPost(Integer postId) {
-        //게시글의 존재 여부 검증
-        Optional<Community> post = Optional.ofNullable(validationUtil.validatePostExists(postId));
-
-        return post.map(CommunityItemDTO::new);
-    }
-
-    /** 게시글 목록 전체 조회 */
-    public Page<CommunityListDTO> getAllPosts(int page, int size) {
-        long totalCount = communityRepository.count();
-        return PaginationService.getPagedData(page, size, totalCount,
-                communityRepository::findAll,
-                CommunityListDTO::new);
-    }
-
 
     /** 댓글 목록 조회 */
     public Page<ParentCommentDTO> getAllComments(Integer postId, int page, int size) {
@@ -63,26 +47,6 @@ public class CommunityService {
         return PaginationService.getPagedData(page, size, totalCount,
                 pageable -> commentRepository.findByParentCommentCommentId(commentId, pageable),
                 repliesDTO::new);
-    }
-
-    /** 게시글 작성 */
-    public CommunityRespDTO writePost(CommunityReqDTO postDTO, String userEmail) {
-        // 유저 검증
-        User user = validationUtil.validateUserExists(userEmail);
-        validationUtil.validateUserRestricted(user);
-
-        // 게시글 생성
-        Community community = new Community();
-        community.setUser(user);
-        community.setTitle(postDTO.getTitle());
-        community.setContents(postDTO.getContent());
-        community.setCreatedAt(LocalDateTime.now());
-        community.setLikeCount(0);
-        community.setCommentCount(0);
-
-        // DB 저장 및 반환
-        communityRepository.save(community);
-        return new CommunityRespDTO(community);
     }
 
     /** 댓글 작성 */
@@ -134,25 +98,6 @@ public class CommunityService {
         communityRepository.save(post);
 
         return new CommentRespDTO(comment);
-    }
-
-    /** 게시물 수정 */
-    public CommunityRespDTO updatePost(CommunityReqDTO postDTO, Integer postId, String userEmail) {
-        //게시글 검증
-        Community post = validationUtil.validatePostExists(postId);
-
-        // 유저 검증
-        User user = validationUtil.validateUserExists(userEmail);
-        validationUtil.validateUserRestricted(user);
-        validationUtil.validateUserIsAuthorOfPost(user, post);
-
-        // 게시글 수정
-        post.setTitle(postDTO.getTitle());
-        post.setContents(postDTO.getContent());
-
-        // DB 저장 및 반환
-        communityRepository.save(post);
-        return new CommunityRespDTO(post);
     }
 
     /** 댓글 수정 */

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
@@ -39,7 +39,8 @@ public class CommentService {
         long totalCount = commentRepository.countByCommunityPostIdAndParentCommentIsNull(postId);
         return PaginationService.getPagedData(page, size, totalCount,
                 pageable -> commentRepository.findByCommunityPostIdAndParentCommentIsNull(postId, pageable),
-                comment -> new ParentCommentDTO(comment, imageService));
+                comment -> new ParentCommentDTO(comment, validationUtil.validateUserExists(comment.getUserId()), imageService)
+        );
     }
 
     /** 답글 목록 조회 */
@@ -49,7 +50,8 @@ public class CommentService {
         long totalCount = commentRepository.countByParentCommentCommentId(commentId);
         return PaginationService.getPagedData(page, size, totalCount,
                 pageable -> commentRepository.findByParentCommentCommentId(commentId, pageable),
-                reply -> new repliesDTO(reply, imageService));
+                reply -> new repliesDTO(reply, validationUtil.validateUserExists(reply.getUserId()), imageService)
+        );
     }
 
     /** 댓글 작성 */

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
@@ -8,6 +8,7 @@ import com.jandi.plan_backend.commu.entity.Comments;
 import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.commu.repository.CommentRepository;
 import com.jandi.plan_backend.commu.repository.CommunityRepository;
+import com.jandi.plan_backend.resource.entity.Banner;
 import com.jandi.plan_backend.storage.service.ImageService;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.util.ValidationUtil;
@@ -121,5 +122,20 @@ public class CommentService {
         // DB 저장 및 반환
         commentRepository.save(comment);
         return new CommentRespDTO(comment);
+    }
+
+    //답글 삭제
+    public boolean deleteReplies(String userEmail, Integer replyId) {
+        // 댓글 검증
+        Comments reply = validationUtil.validateCommentExists(replyId);
+
+        // 유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserRestricted(user);
+        validationUtil.validateUserIsAuthorOfComment(user, reply);
+
+        //배너 삭제 및 반환
+        commentRepository.delete(reply);
+        return true;
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
@@ -8,6 +8,7 @@ import com.jandi.plan_backend.commu.entity.Comments;
 import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.commu.repository.CommentRepository;
 import com.jandi.plan_backend.commu.repository.CommunityRepository;
+import com.jandi.plan_backend.storage.service.ImageService;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.util.ValidationUtil;
 import com.jandi.plan_backend.util.service.PaginationService;
@@ -21,12 +22,14 @@ public class CommentService {
     private final CommunityRepository communityRepository;
     private final CommentRepository commentRepository;
     private final ValidationUtil validationUtil;
+    private final ImageService imageService;
 
     // 생성자를 통해 필요한 의존성들을 주입받음.
-    public CommentService(CommunityRepository communityRepository, CommentRepository commentRepository, ValidationUtil validationUtil) {
+    public CommentService(CommunityRepository communityRepository, CommentRepository commentRepository, ValidationUtil validationUtil, ImageService imageService) {
         this.communityRepository = communityRepository;
         this.commentRepository = commentRepository;
         this.validationUtil = validationUtil;
+        this.imageService = imageService;
     }
 
     /** 댓글 목록 조회 */
@@ -36,7 +39,7 @@ public class CommentService {
         long totalCount = commentRepository.countByCommunityPostIdAndParentCommentIsNull(postId);
         return PaginationService.getPagedData(page, size, totalCount,
                 pageable -> commentRepository.findByCommunityPostIdAndParentCommentIsNull(postId, pageable),
-                ParentCommentDTO::new);
+                comment -> new ParentCommentDTO(comment, imageService));
     }
 
     /** 답글 목록 조회 */
@@ -46,7 +49,7 @@ public class CommentService {
         long totalCount = commentRepository.countByParentCommentCommentId(commentId);
         return PaginationService.getPagedData(page, size, totalCount,
                 pageable -> commentRepository.findByParentCommentCommentId(commentId, pageable),
-                repliesDTO::new);
+                reply -> new repliesDTO(reply, imageService));
     }
 
     /** 댓글 작성 */

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommunityService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommunityService.java
@@ -146,9 +146,9 @@ public class CommunityService {
         validationUtil.validateUserRestricted(user);
         validationUtil.validateUserIsAuthorOfPost(user, post);
 
-        // 게시글 수정: 빈 값이 아닐 때만 수정되게 함
-        if(postDTO.getTitle()!=null) post.setTitle(postDTO.getTitle());
-        if(postDTO.getContent()!=null) post.setContents(postDTO.getContent());
+        // 게시글 수정
+        post.setTitle(postDTO.getTitle());
+        post.setContents(postDTO.getContent());
 
         // DB 저장 및 반환
         communityRepository.save(post);
@@ -165,8 +165,8 @@ public class CommunityService {
         validationUtil.validateUserRestricted(user);
         validationUtil.validateUserIsAuthorOfComment(user, comment);
 
-        //댓글 수정: 빈 값이 아닐 때만 수정되게 함
-        if(commentDTO.getContents()!=null) comment.setContents(commentDTO.getContents());
+        //댓글 수정
+        comment.setContents(commentDTO.getContents());
 
         // DB 저장 및 반환
         commentRepository.save(comment);

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -5,6 +5,7 @@ import com.jandi.plan_backend.commu.entity.Comments;
 import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.commu.repository.CommentRepository;
 import com.jandi.plan_backend.commu.repository.CommunityRepository;
+import com.jandi.plan_backend.storage.service.ImageService;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.util.ValidationUtil;
 import org.springframework.data.domain.Page;
@@ -18,14 +19,15 @@ import java.util.Optional;
 public class PostService {
 
     private final CommunityRepository communityRepository;
-    private final CommentRepository commentRepository;
     private final ValidationUtil validationUtil;
+    private final ImageService imageService;
 
     // 생성자를 통해 필요한 의존성들을 주입받음.
-    public PostService(CommunityRepository communityRepository, CommentRepository commentRepository, ValidationUtil validationUtil) {
+    public PostService(
+            CommunityRepository communityRepository, ValidationUtil validationUtil, ImageService imageService) {
         this.communityRepository = communityRepository;
-        this.commentRepository = commentRepository;
         this.validationUtil = validationUtil;
+        this.imageService = imageService;
     }
 
     /** 특정 게시글 조회 */
@@ -33,7 +35,7 @@ public class PostService {
         //게시글의 존재 여부 검증
         Optional<Community> post = Optional.ofNullable(validationUtil.validatePostExists(postId));
 
-        return post.map(CommunityItemDTO::new);
+        return post.map(p -> new CommunityItemDTO(p, imageService)); // imageService 포함
     }
 
     /** 게시글 목록 전체 조회 */
@@ -41,7 +43,7 @@ public class PostService {
         long totalCount = communityRepository.count();
         return PaginationService.getPagedData(page, size, totalCount,
                 communityRepository::findAll,
-                CommunityListDTO::new);
+                community -> new CommunityListDTO(community, imageService)); // imageService 포함
     }
 
     /** 게시글 작성 */
@@ -61,7 +63,7 @@ public class PostService {
 
         // DB 저장 및 반환
         communityRepository.save(community);
-        return new CommunityRespDTO(community);
+        return new CommunityRespDTO(community, imageService);
     }
 
 
@@ -81,7 +83,7 @@ public class PostService {
 
         // DB 저장 및 반환
         communityRepository.save(post);
-        return new CommunityRespDTO(post);
+        return new CommunityRespDTO(post, imageService);
     }
 
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -1,0 +1,87 @@
+package com.jandi.plan_backend.commu.service;
+
+import com.jandi.plan_backend.commu.dto.*;
+import com.jandi.plan_backend.commu.entity.Comments;
+import com.jandi.plan_backend.commu.entity.Community;
+import com.jandi.plan_backend.commu.repository.CommentRepository;
+import com.jandi.plan_backend.commu.repository.CommunityRepository;
+import com.jandi.plan_backend.user.entity.User;
+import com.jandi.plan_backend.util.ValidationUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import com.jandi.plan_backend.util.service.PaginationService;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class PostService {
+
+    private final CommunityRepository communityRepository;
+    private final CommentRepository commentRepository;
+    private final ValidationUtil validationUtil;
+
+    // 생성자를 통해 필요한 의존성들을 주입받음.
+    public PostService(CommunityRepository communityRepository, CommentRepository commentRepository, ValidationUtil validationUtil) {
+        this.communityRepository = communityRepository;
+        this.commentRepository = commentRepository;
+        this.validationUtil = validationUtil;
+    }
+
+    /** 특정 게시글 조회 */
+    public Optional<CommunityItemDTO> getSpecPost(Integer postId) {
+        //게시글의 존재 여부 검증
+        Optional<Community> post = Optional.ofNullable(validationUtil.validatePostExists(postId));
+
+        return post.map(CommunityItemDTO::new);
+    }
+
+    /** 게시글 목록 전체 조회 */
+    public Page<CommunityListDTO> getAllPosts(int page, int size) {
+        long totalCount = communityRepository.count();
+        return PaginationService.getPagedData(page, size, totalCount,
+                communityRepository::findAll,
+                CommunityListDTO::new);
+    }
+
+    /** 게시글 작성 */
+    public CommunityRespDTO writePost(CommunityReqDTO postDTO, String userEmail) {
+        // 유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserRestricted(user);
+
+        // 게시글 생성
+        Community community = new Community();
+        community.setUser(user);
+        community.setTitle(postDTO.getTitle());
+        community.setContents(postDTO.getContent());
+        community.setCreatedAt(LocalDateTime.now());
+        community.setLikeCount(0);
+        community.setCommentCount(0);
+
+        // DB 저장 및 반환
+        communityRepository.save(community);
+        return new CommunityRespDTO(community);
+    }
+
+
+    /** 게시물 수정 */
+    public CommunityRespDTO updatePost(CommunityReqDTO postDTO, Integer postId, String userEmail) {
+        //게시글 검증
+        Community post = validationUtil.validatePostExists(postId);
+
+        // 유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserRestricted(user);
+        validationUtil.validateUserIsAuthorOfPost(user, post);
+
+        // 게시글 수정
+        post.setTitle(postDTO.getTitle());
+        post.setContents(postDTO.getContent());
+
+        // DB 저장 및 반환
+        communityRepository.save(post);
+        return new CommunityRespDTO(post);
+    }
+
+}

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -10,6 +10,8 @@ import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.util.ValidationUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import com.jandi.plan_backend.util.service.PaginationService;
 
@@ -46,9 +48,13 @@ public class PostService {
     /** 게시글 목록 전체 조회 */
     public Page<CommunityListDTO> getAllPosts(int page, int size) {
         long totalCount = communityRepository.count();
+
+        // postId 내림차순 정렬
+        Sort sort = Sort.by(Sort.Direction.DESC, "postId");
+
         return PaginationService.getPagedData(page, size, totalCount,
-                communityRepository::findAll,
-                community -> new CommunityListDTO(community, imageService)); // imageService 포함
+                (pageable) -> communityRepository.findAll(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort)),
+                community -> new CommunityListDTO(community, imageService));
     }
 
     /** 게시글 작성 */

--- a/src/main/java/com/jandi/plan_backend/resource/controller/BannerController.java
+++ b/src/main/java/com/jandi/plan_backend/resource/controller/BannerController.java
@@ -77,7 +77,7 @@ public class BannerController {
         String jwtToken = token.replace("Bearer ", "");
         String userEmail = jwtTokenProvider.getEmail(jwtToken);
 
-        // 배너 수정 및 반환
+        // 배너 삭제 및 반환
         String returnMsg = (bannerService.deleteBanner(userEmail, bannerId)) ?
                 "삭제되었습니다" : "삭제 과정에서 문제가 발생했습니다. 다시 한번 시도해주세요";
         return ResponseEntity.ok(returnMsg);

--- a/src/main/java/com/jandi/plan_backend/resource/controller/BannerController.java
+++ b/src/main/java/com/jandi/plan_backend/resource/controller/BannerController.java
@@ -67,4 +67,19 @@ public class BannerController {
         return ResponseEntity.ok(updatedBanner);
     }
 
+    /** 배너 삭제 API */
+    @DeleteMapping("/lists/{bannerId}")
+    public ResponseEntity<?> deleteBanner(
+            @PathVariable Integer bannerId, //삭제할 bannerId
+            @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        // 배너 수정 및 반환
+        String returnMsg = (bannerService.deleteBanner(userEmail, bannerId)) ?
+                "삭제되었습니다" : "삭제 과정에서 문제가 발생했습니다. 다시 한번 시도해주세요";
+        return ResponseEntity.ok(returnMsg);
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/resource/controller/BannerController.java
+++ b/src/main/java/com/jandi/plan_backend/resource/controller/BannerController.java
@@ -3,7 +3,6 @@ package com.jandi.plan_backend.resource.controller;
 import com.jandi.plan_backend.resource.dto.*;
 import com.jandi.plan_backend.resource.service.BannerService;
 import com.jandi.plan_backend.security.JwtTokenProvider;
-import com.jandi.plan_backend.storage.service.ImageService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,7 +16,7 @@ public class BannerController {
     private final BannerService bannerService;
     private final JwtTokenProvider jwtTokenProvider; // JWT 토큰 관련
 
-    public BannerController(BannerService bannerService, JwtTokenProvider jwtTokenProvider, ImageService imageService) {
+    public BannerController(BannerService bannerService, JwtTokenProvider jwtTokenProvider) {
         this.bannerService = bannerService;
         this.jwtTokenProvider = jwtTokenProvider;
     }
@@ -35,7 +34,7 @@ public class BannerController {
 
     /** 배너 작성 API */
     @PostMapping("/lists")
-    public ResponseEntity writeBanner(
+    public ResponseEntity<?> writeBanner(
             @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
             @RequestParam MultipartFile file, //imageUrl에 넣을 원본 파일
             @RequestParam String title, //배너 제목
@@ -46,8 +45,26 @@ public class BannerController {
         String userEmail = jwtTokenProvider.getEmail(jwtToken);
 
         // 배너 저장 및 반환
-        BannerRespDTO savedNotice = bannerService.writeBanner(userEmail, file, title, linkUrl);
-        return ResponseEntity.ok(savedNotice);
+        BannerRespDTO savedBanner = bannerService.writeBanner(userEmail, file, title, linkUrl);
+        return ResponseEntity.ok(savedBanner);
+    }
+
+    /** 배너 수정 API */
+    @PatchMapping("/lists/{bannerId}")
+    public ResponseEntity<?> updateBanner(
+            @PathVariable Integer bannerId,
+            @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
+            @RequestParam MultipartFile file, //imageUrl에 넣을 원본 파일
+            @RequestParam String title, //배너 제목
+            @RequestParam String linkUrl //배너 클릭 시 연결할 link
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        // 배너 수정 및 반환
+        BannerRespDTO updatedBanner = bannerService.updateBanner(userEmail, bannerId, file, title, linkUrl);
+        return ResponseEntity.ok(updatedBanner);
     }
 
 }

--- a/src/main/java/com/jandi/plan_backend/resource/controller/NoticeController.java
+++ b/src/main/java/com/jandi/plan_backend/resource/controller/NoticeController.java
@@ -67,6 +67,20 @@ public class NoticeController {
         return ResponseEntity.ok(savedNotice);
     }
 
+    /** 공지사항 삭제 API */
+    @DeleteMapping("/lists/{noticeId}")
+    public ResponseEntity<?> deleteNotice(
+            @PathVariable Integer noticeId, //삭제할 공지사항
+            @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
 
+        // 배너 수정 및 반환
+        String returnMsg = (noticeService.deleteNotice(userEmail, noticeId)) ?
+                "삭제되었습니다" : "삭제 과정에서 문제가 발생했습니다. 다시 한번 시도해주세요";
+        return ResponseEntity.ok(returnMsg);
+    }
 }
 

--- a/src/main/java/com/jandi/plan_backend/resource/controller/NoticeController.java
+++ b/src/main/java/com/jandi/plan_backend/resource/controller/NoticeController.java
@@ -50,6 +50,23 @@ public class NoticeController {
         return ResponseEntity.ok(savedNotice);
     }
 
+    /** 공지사항 수정 API */
+    @PatchMapping("/lists/{noticeId}")
+    public ResponseEntity<?> updateNotice(
+            @PathVariable Integer noticeId, //링크에서 noticeId 받기
+            @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
+            @RequestBody NoticeReqDTO noticeDTO // JSON 형식으로 공지글 작성 정보 받기
+    ){
+
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        // 공지글 저장 및 반환
+        NoticeRespDTO savedNotice = noticeService.updateNotice(noticeDTO, noticeId, userEmail);
+        return ResponseEntity.ok(savedNotice);
+    }
+
 
 }
 

--- a/src/main/java/com/jandi/plan_backend/resource/controller/NoticeController.java
+++ b/src/main/java/com/jandi/plan_backend/resource/controller/NoticeController.java
@@ -77,7 +77,7 @@ public class NoticeController {
         String jwtToken = token.replace("Bearer ", "");
         String userEmail = jwtTokenProvider.getEmail(jwtToken);
 
-        // 배너 수정 및 반환
+        // 공지 삭제 및 반환
         String returnMsg = (noticeService.deleteNotice(userEmail, noticeId)) ?
                 "삭제되었습니다" : "삭제 과정에서 문제가 발생했습니다. 다시 한번 시도해주세요";
         return ResponseEntity.ok(returnMsg);

--- a/src/main/java/com/jandi/plan_backend/resource/entity/Banner.java
+++ b/src/main/java/com/jandi/plan_backend/resource/entity/Banner.java
@@ -25,7 +25,7 @@ public class Banner {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer BannerId;
+    private Integer bannerId;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/jandi/plan_backend/resource/repository/BannerRepository.java
+++ b/src/main/java/com/jandi/plan_backend/resource/repository/BannerRepository.java
@@ -1,7 +1,12 @@
 package com.jandi.plan_backend.resource.repository;
 
+import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.resource.entity.Banner;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BannerRepository extends JpaRepository<Banner, Long> {
+    // 배너글이 존재하는지 조회하는 메서드
+    Optional<Banner> findByBannerId(Integer bannerId);
 }

--- a/src/main/java/com/jandi/plan_backend/resource/repository/NoticeRepository.java
+++ b/src/main/java/com/jandi/plan_backend/resource/repository/NoticeRepository.java
@@ -1,7 +1,12 @@
 package com.jandi.plan_backend.resource.repository;
 
+import com.jandi.plan_backend.resource.entity.Banner;
 import com.jandi.plan_backend.resource.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface NoticeRepository extends JpaRepository<Notice, Integer> {
+    // 공지글이 존재하는지 조회하는 메서드
+    Optional<Notice> findByNoticeId(Integer noticeId);
 }

--- a/src/main/java/com/jandi/plan_backend/resource/service/BannerService.java
+++ b/src/main/java/com/jandi/plan_backend/resource/service/BannerService.java
@@ -5,7 +5,6 @@ import com.jandi.plan_backend.resource.dto.BannerRespDTO;
 import com.jandi.plan_backend.resource.entity.Banner;
 import com.jandi.plan_backend.resource.repository.BannerRepository;
 import com.jandi.plan_backend.storage.dto.ImageResponseDto;
-import com.jandi.plan_backend.storage.entity.Image;
 import com.jandi.plan_backend.storage.repository.ImageRepository;
 import com.jandi.plan_backend.storage.service.ImageService;
 import com.jandi.plan_backend.user.entity.User;
@@ -15,7 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -89,5 +87,18 @@ public class BannerService {
         //수정된 배너 반환
         bannerRepository.save(banner);
         return new BannerRespDTO(banner);
+    }
+
+    public boolean deleteBanner(String userEmail, Integer bannerId) {
+        //유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserIsAdmin(user);
+
+        //배너글 검증
+        Banner banner = validationUtil.validateBannerExists(bannerId);
+
+        //배너 삭제 및 반환
+        bannerRepository.delete(banner);
+        return true;
     }
 }

--- a/src/main/java/com/jandi/plan_backend/resource/service/BannerService.java
+++ b/src/main/java/com/jandi/plan_backend/resource/service/BannerService.java
@@ -5,6 +5,8 @@ import com.jandi.plan_backend.resource.dto.BannerRespDTO;
 import com.jandi.plan_backend.resource.entity.Banner;
 import com.jandi.plan_backend.resource.repository.BannerRepository;
 import com.jandi.plan_backend.storage.dto.ImageResponseDto;
+import com.jandi.plan_backend.storage.entity.Image;
+import com.jandi.plan_backend.storage.repository.ImageRepository;
 import com.jandi.plan_backend.storage.service.ImageService;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.util.ValidationUtil;
@@ -13,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,13 +23,15 @@ public class BannerService {
     private final BannerRepository bannerRepository;
     private final ValidationUtil validationUtil;
     private final ImageService imageService;
+    private final ImageRepository imageRepository;
 
 
     //생성자를 통한 의존성 주입
-    public BannerService(BannerRepository bannerRepository, ValidationUtil validationUtil, ImageService imageService) {
+    public BannerService(BannerRepository bannerRepository, ValidationUtil validationUtil, ImageService imageService, ImageRepository imageRepository) {
         this.bannerRepository = bannerRepository;
         this.validationUtil = validationUtil;
         this.imageService = imageService;
+        this.imageRepository = imageRepository;
     }
 
     /** 전체 배너 목록 조회*/
@@ -37,7 +42,8 @@ public class BannerService {
     }
 
     /** 배너글 작성 */
-    public BannerRespDTO writeBanner(String email, MultipartFile file, String title, String link) {
+    public BannerRespDTO writeBanner(
+            String email, MultipartFile file, String title, String link) {
         //유저 검증
         User user = validationUtil.validateUserExists(email);
         validationUtil.validateUserIsAdmin(user);
@@ -56,6 +62,32 @@ public class BannerService {
 
         //DB 최종 저장 및 반환
         bannerRepository.save(banner); //imageUrl 포함하여 저장
+        return new BannerRespDTO(banner);
+    }
+
+    /** 배너글 수정 */
+    public BannerRespDTO updateBanner(
+            String email, Integer bannerId, MultipartFile file, String title, String link) {
+        //유저 검증
+        User user = validationUtil.validateUserExists(email);
+        validationUtil.validateUserIsAdmin(user);
+
+        //배너글 검증
+        Banner banner = validationUtil.validateBannerExists(bannerId);
+
+        //배너 수정: 값이 있는 것만 수정
+        if (title != null) { banner.setTitle(title); }
+        if (link != null) { banner.setLinkUrl(link); }
+        if (file != null) {
+            imageRepository.findByTargetTypeAndTargetId("banner", bannerId)
+                    .ifPresent(imageRepository::delete); //기존 이미지 삭제
+            ImageResponseDto image = imageService.uploadImage(
+                    file, user.getEmail(), bannerId, "banner"); //재업로드
+            banner.setImageUrl(image.getImageUrl()); //업로드된 imageUrl 저장
+        }
+
+        //수정된 배너 반환
+        bannerRepository.save(banner);
         return new BannerRespDTO(banner);
     }
 }

--- a/src/main/java/com/jandi/plan_backend/resource/service/NoticeService.java
+++ b/src/main/java/com/jandi/plan_backend/resource/service/NoticeService.java
@@ -61,4 +61,17 @@ public class NoticeService {
         noticeRepository.save(notice);
         return new NoticeRespDTO(notice);
     }
+
+    public boolean deleteNotice(String userEmail, Integer noticeId) {
+        // 유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserIsAdmin(user);
+
+        // 공지글 검증
+        Notice notice = validationUtil.validateNoticeExists(noticeId);
+
+        // 공지글 삭제 및 반환
+        noticeRepository.delete(notice);
+        return true;
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/resource/service/NoticeService.java
+++ b/src/main/java/com/jandi/plan_backend/resource/service/NoticeService.java
@@ -29,9 +29,9 @@ public class NoticeService {
     }
 
     /** 공지글 작성 */
-    public NoticeRespDTO writeNotice(NoticeReqDTO noticeDTO, String email) {
+    public NoticeRespDTO writeNotice(NoticeReqDTO noticeDTO, String userEmail) {
         // 유저 검증
-        User user = validationUtil.validateUserExists(email);
+        User user = validationUtil.validateUserExists(userEmail);
         validationUtil.validateUserIsAdmin(user);
 
         // 공지글 생성
@@ -41,6 +41,23 @@ public class NoticeService {
         notice.setContents(noticeDTO.getContents());
 
         // DB 저장 및 반환
+        noticeRepository.save(notice);
+        return new NoticeRespDTO(notice);
+    }
+
+    public NoticeRespDTO updateNotice(NoticeReqDTO noticeDTO, Integer noticeId, String userEmail) {
+        // 유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserIsAdmin(user);
+
+        // 공지글 검증
+        Notice notice = validationUtil.validateNoticeExists(noticeId);
+
+        // 공지 수정: 값이 있는 것만 수정
+        if(noticeDTO.getTitle() != null) { notice.setTitle(noticeDTO.getTitle()); }
+        if(noticeDTO.getContents() != null) { notice.setContents(noticeDTO.getContents()); }
+
+        //수정된 공지 반환
         noticeRepository.save(notice);
         return new NoticeRespDTO(notice);
     }

--- a/src/main/java/com/jandi/plan_backend/storage/service/ImageService.java
+++ b/src/main/java/com/jandi/plan_backend/storage/service/ImageService.java
@@ -80,4 +80,9 @@ public class ImageService {
         return imageOptional.map(img -> publicUrlPrefix + img.getImageUrl())
                 .orElse(null);
     }
+
+    public String getUserProfile(Integer userId) {
+        Optional<Image> imageOptional = imageRepository.findByTargetTypeAndTargetId("userProfile", userId);
+        return imageOptional.map(img -> publicUrlPrefix + img.getImageUrl()).orElse(null);
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/jandi/plan_backend/user/repository/UserRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
  * JpaRepository를 확장하여 CRUD 및 페이징 기능 등을 기본 제공.
  */
 public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByUserId(Integer userId);
 
     /**
      * 주어진 이메일을 가진 User 엔티티를 Optional로 반환.

--- a/src/main/java/com/jandi/plan_backend/user/service/ProfileImageService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/ProfileImageService.java
@@ -32,7 +32,7 @@ public class ProfileImageService {
      * @return 업로드 결과를 담은 ImageResponseDto
      */
     public ImageResponseDto uploadProfileImage(MultipartFile file, String ownerEmail, Integer userId) {
-        String targetType = "profile";
+        String targetType = "userProfile";
         return imageService.uploadImage(file, ownerEmail, userId, targetType);
     }
 
@@ -43,7 +43,7 @@ public class ProfileImageService {
      * @return 해당 프로필 사진 Image 엔티티 (Optional)
      */
     public Optional<Image> getProfileImage(Integer userId) {
-        return imageRepository.findByTargetTypeAndTargetId("profile", userId);
+        return imageRepository.findByTargetTypeAndTargetId("userProfile", userId);
     }
 
     /**

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -35,6 +35,11 @@ public class ValidationUtil {
                 .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 사용자입니다."));
     }
 
+    public User validateUserExists(Integer userId) {
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 사용자입니다."));
+    }
+
     // 사용자 활동 제한 여부 검증
     public void validateUserRestricted(User user) {
         if (user.getReported()) {

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -5,7 +5,10 @@ import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.commu.repository.CommentRepository;
 import com.jandi.plan_backend.commu.repository.CommunityRepository;
 import com.jandi.plan_backend.resource.entity.Banner;
+import com.jandi.plan_backend.resource.entity.Notice;
 import com.jandi.plan_backend.resource.repository.BannerRepository;
+import com.jandi.plan_backend.resource.repository.NoticeRepository;
+import com.jandi.plan_backend.resource.service.NoticeService;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.user.repository.UserRepository;
 import com.jandi.plan_backend.util.service.BadRequestExceptionMessage;
@@ -20,12 +23,14 @@ public class ValidationUtil {
     private final CommunityRepository communityRepository;
     private final CommentRepository commentRepository;
     private final BannerRepository bannerRepository;
+    private final NoticeRepository noticeRepository;
 
-    public ValidationUtil(UserRepository userRepository, CommunityRepository communityRepository, CommentRepository commentRepository, BannerRepository bannerRepository) {
+    public ValidationUtil(UserRepository userRepository, CommunityRepository communityRepository, CommentRepository commentRepository, BannerRepository bannerRepository, NoticeRepository noticeRepository) {
         this.userRepository = userRepository;
         this.communityRepository = communityRepository;
         this.commentRepository = commentRepository;
         this.bannerRepository = bannerRepository;
+        this.noticeRepository = noticeRepository;
     }
 
     /** userRepository */
@@ -84,5 +89,12 @@ public class ValidationUtil {
     public Banner validateBannerExists(Integer bannerId) {
         return (Banner) bannerRepository.findByBannerId(bannerId)
                 .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 배너입니다."));
+    }
+
+
+    /** NoticeRepository 관련 검증 */
+    public Notice validateNoticeExists(Integer noticeId) {
+        return (Notice) noticeRepository.findByNoticeId(noticeId)
+                .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 공지입니다."));
     }
 }

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -4,6 +4,8 @@ import com.jandi.plan_backend.commu.entity.Comments;
 import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.commu.repository.CommentRepository;
 import com.jandi.plan_backend.commu.repository.CommunityRepository;
+import com.jandi.plan_backend.resource.entity.Banner;
+import com.jandi.plan_backend.resource.repository.BannerRepository;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.user.repository.UserRepository;
 import com.jandi.plan_backend.util.service.BadRequestExceptionMessage;
@@ -17,11 +19,13 @@ public class ValidationUtil {
     private final UserRepository userRepository;
     private final CommunityRepository communityRepository;
     private final CommentRepository commentRepository;
+    private final BannerRepository bannerRepository;
 
-    public ValidationUtil(UserRepository userRepository, CommunityRepository communityRepository, CommentRepository commentRepository) {
+    public ValidationUtil(UserRepository userRepository, CommunityRepository communityRepository, CommentRepository commentRepository, BannerRepository bannerRepository) {
         this.userRepository = userRepository;
         this.communityRepository = communityRepository;
         this.commentRepository = commentRepository;
+        this.bannerRepository = bannerRepository;
     }
 
     /** userRepository */
@@ -68,5 +72,12 @@ public class ValidationUtil {
     public void validateUserIsAuthorOfComment(User user, Comments comment) {
         if(!Objects.equals(user.getUserId(), comment.getUserId()))
             throw new BadRequestExceptionMessage("작성자 본인만 수정할 수 있습니다.");
+    }
+
+    /** BannerRepository 관련 검증 */
+    //배너의 존재 여부 검증
+    public Banner validateBannerExists(Integer bannerId) {
+        return (Banner) bannerRepository.findByBannerId(bannerId)
+                .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 배너입니다."));
     }
 }


### PR DESCRIPTION
## 작업 내용
- 배너 수정, 공지사항 수정, 배너 삭제, 공지사항 삭제, 댓글 삭제, 게시물 삭제 API 추가
- 댓글 불러올 때 `userId` 대신 `userCommunityDTO` 정보 형식으로 불러오도록 수정
- 게시글, 댓글을 조회할 때 작성자의 프로필이미지를 함께 불러오도록 수정
- 게시물, 댓글 작성 시 다 작성하지 않으면 에러나게끔 수정

## 전달 사항
- 가독성을 위해 `CommunityController`를 게시물만 담당하는 `postController`와 댓글만 담당하는 `commentController`로 분리
- 가독성을 위해 `CommunityService`도 동일하게 `post / commentController`로 분리
- `ImageService`에 유저 프로필을 불러오기 위한 `getUserProfile()` 메서드 추가
- `image` 엔티티에서 유저 프로필에 대한 `targetType`을 "userProfile"로 변경
-> 추후 여행 계획 리스트에서 배경(=프로필)을 지정할 수도 있고, profile보단 userProfile이 더 명확하게 역할을 설명한다고 생각하여 수정했는데 별로라면 무시하셔도 좋습니다!

## 논의 사항
- 관리자 검증 및 권한 부여 로직에 대해 논의 필요
-> `util/ValidationUtil.java`의 `validateUserIsAdmin()`같은 검증 메서드나 `PostService.java`의 `deletePost()`같은 삭제 메서드에서 그냥 `userId==1`이면 관리자로 판별하고 있는데 이게 보안상 문제가 있진 않을지 고민됩니다....