### PR TITLE
Feat: 여행지 DB 조회 및 추가, 닉네임/이메일 중복확인 API 추가

### DIFF
--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityItemDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityItemDTO.java
@@ -19,9 +19,12 @@ public class CommunityItemDTO {
     private final String content;
     private final Integer likeCount;
     private final Integer commentCount;
+    private final Integer viewCount;
+
 
     public CommunityItemDTO(Community community, ImageService imageService) {
         this.postId = community.getPostId();
+        this.viewCount = community.getViewCount();
         this.user = new UserCommunityDTO(community.getUser(), imageService);
         this.createdAt = community.getCreatedAt();
         this.title = community.getTitle();

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -18,9 +18,11 @@ public class CommunityListDTO {
     private final String title;
     private final Integer likeCount;
     private final Integer commentCount;
+    private final Integer viewCount;
 
     public CommunityListDTO(Community community, ImageService imageService) {
         this.postId = community.getPostId();
+        this.viewCount = community.getViewCount();
         this.user = new UserCommunityDTO(community.getUser(), imageService);
         this.createdAt = community.getCreatedAt();
         this.title = community.getTitle();

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityRespDTO.java
@@ -18,6 +18,7 @@ public class CommunityRespDTO {
     private LocalDateTime createdAt;
     private int likeCount;
     private int commentCount;
+    private int viewCount;
     private UserCommunityDTO user; // 유저 정보 중 민감 정보 제외
 
     public CommunityRespDTO(Community community, ImageService imageService) {
@@ -27,6 +28,7 @@ public class CommunityRespDTO {
         this.title = community.getTitle();
         this.content = community.getContents();
         this.likeCount = community.getLikeCount();
+        this.viewCount = community.getViewCount();
         this.commentCount = community.getCommentCount();
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
+++ b/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
@@ -48,6 +48,10 @@ public class Community {
     @Column(nullable = false)
     private Integer likeCount;
 
+    // 게시글의 조회 수. null 값은 허용되지 않음.
+    @Column(nullable = false)
+    private Integer viewCount;
+
     @Column(nullable = false)
     private Integer commentCount; //댓글 수
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -40,8 +40,14 @@ public class PostService {
     /** 특정 게시글 조회 */
     public Optional<CommunityItemDTO> getSpecPost(Integer postId) {
         //게시글의 존재 여부 검증
-        Optional<Community> post = Optional.ofNullable(validationUtil.validatePostExists(postId));
+        Community community = validationUtil.validatePostExists(postId);
 
+        //게시글 조회수 카운팅
+        community.setViewCount(community.getViewCount() + 1);
+        communityRepository.save(community);
+
+        //게시글 반환
+        Optional<Community> post = communityRepository.findByPostId(postId);
         return post.map(p -> new CommunityItemDTO(p, imageService)); // imageService 포함
     }
 

--- a/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
+++ b/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
                 // 요청에 대한 접근 권한 설정
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
-                                "/api/users/login", "/api/users/register", "/api/users/forgot", "/api/users/verify",
+                                "/api/users/login", "/api/users/register", "/api/users/register/checkEmail","/api/users/register/checkName", "/api/users/forgot", "/api/users/verify",
                                 "/api/users/token/refresh","/api/notice/lists",
                                 "api/community/posts", "api/community/posts/*",
                                 "api/community/comments", "api/community/comments/{postId}",

--- a/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
+++ b/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
@@ -75,7 +75,8 @@ public class SecurityConfig {
                                 "api/community/comments", "api/community/comments/{postId}",
                                 "api/community/replies/{commentId}", "api/community/posts", 
                                 "/api/images/**",
-                                "/api/banner/lists"
+                                "/api/banner/lists",
+                                "/api/trip/*"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/jandi/plan_backend/storage/controller/ImageController.java
+++ b/src/main/java/com/jandi/plan_backend/storage/controller/ImageController.java
@@ -2,6 +2,8 @@ package com.jandi.plan_backend.storage.controller;
 
 import com.jandi.plan_backend.storage.dto.ImageResponseDto;
 import com.jandi.plan_backend.storage.service.ImageService;
+import com.jandi.plan_backend.user.entity.MajorDestination;
+import com.jandi.plan_backend.user.repository.MajorDestinationRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,9 +30,11 @@ import java.util.Optional;
 public class ImageController {
 
     private final ImageService imageService;
+    private final MajorDestinationRepository majorDestinationRepository;
 
-    public ImageController(ImageService imageService) {
+    public ImageController(ImageService imageService, MajorDestinationRepository majorDestinationRepository) {
         this.imageService = imageService;
+        this.majorDestinationRepository = majorDestinationRepository;
     }
 
     /**

--- a/src/main/java/com/jandi/plan_backend/user/controller/ManageTripController.java
+++ b/src/main/java/com/jandi/plan_backend/user/controller/ManageTripController.java
@@ -1,0 +1,80 @@
+package com.jandi.plan_backend.user.controller;
+
+import com.jandi.plan_backend.user.entity.Continent;
+import com.jandi.plan_backend.user.entity.Country;
+import com.jandi.plan_backend.user.entity.MajorDestination;
+import com.jandi.plan_backend.user.service.TripService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/manage/trip")
+public class ManageTripController {
+
+    private final TripService tripService;
+
+    public ManageTripController(TripService tripService) {
+        this.tripService = tripService;}
+
+    /** 업로드 */
+    // 여행 대륙 업로드
+    @PostMapping("/continents")
+    public ResponseEntity<?> uploadContinent(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("continent") String continentName,
+            @RequestParam("file") MultipartFile file
+    ) {
+        if(userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
+        }
+
+        String userEmail = userDetails.getUsername();
+        Continent newCountry = tripService.createNewContinent(userEmail, continentName, file);
+
+        return ResponseEntity.ok(newCountry);
+    }
+
+    // 여행 국가 업로드
+    @PostMapping("/countries")
+    public ResponseEntity<?> uploadCountry(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("continent") String continentName,
+            @RequestParam("country") String countryName
+    ) {
+        if(userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
+        }
+
+        String userEmail = userDetails.getUsername();
+        Country newCountry = tripService.createNewCountry(userEmail, continentName, countryName);
+
+        return ResponseEntity.ok(newCountry);
+    }
+
+    // 여행 도시 업로드
+    @PostMapping("/cities")
+    public ResponseEntity<?> uploadCity(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam("country") String countryName,
+            @RequestParam("city") String cityName,
+            @RequestParam("description") String description,
+            @RequestParam("file") MultipartFile file
+    ) {
+        if(userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
+        }
+
+        String userEmail = userDetails.getUsername();
+        MajorDestination newCity = tripService.createNewCity(
+                userEmail, countryName, cityName, description, file
+        );
+
+        return ResponseEntity.ok(newCity);
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/user/controller/UserController.java
+++ b/src/main/java/com/jandi/plan_backend/user/controller/UserController.java
@@ -46,8 +46,12 @@ public class UserController {
     public ResponseEntity<?> checkEmail(
             @RequestParam ("email") String email
     ) {
+        if(email == null || email.isEmpty()) {
+            return ResponseEntity.badRequest().body("이메일을 입력해주세요!");
+        }
+
         boolean isPossibleEmail = !userService.isExistEmail(email);
-        String respMsg = email + "은 " + ((isPossibleEmail) ?
+        String respMsg = email + "은/는 " + ((isPossibleEmail) ?
                 "사용 가능한 이메일입니다" : "이미 사용중인 이메일입니다");
 
         return (isPossibleEmail) ? ResponseEntity.ok(respMsg) : ResponseEntity.badRequest().body(respMsg);
@@ -57,8 +61,12 @@ public class UserController {
     public ResponseEntity<?> checkName(
             @RequestParam ("name") String name
     ) {
+        if(name == null || name.isEmpty()) {
+            return ResponseEntity.badRequest().body("닉네임을 입력해주세요!");
+        }
+
         boolean isPossibleEmail = !userService.isExistUserName(name);
-        String respMsg = name + "은 " + ((isPossibleEmail) ?
+        String respMsg = name + "은/는 " + ((isPossibleEmail) ?
                 "사용 가능한 닉네임입니다" : "이미 사용중인 닉네임입니다");
 
         return (isPossibleEmail) ? ResponseEntity.ok(respMsg) : ResponseEntity.badRequest().body(respMsg);

--- a/src/main/java/com/jandi/plan_backend/user/controller/UserController.java
+++ b/src/main/java/com/jandi/plan_backend/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.jandi.plan_backend.user.controller;
 
+import com.jandi.plan_backend.security.CustomUserDetails;
 import com.jandi.plan_backend.user.dto.*;
 import com.jandi.plan_backend.user.service.UserService;
 import com.jandi.plan_backend.security.JwtTokenProvider;
@@ -39,6 +40,29 @@ public class UserController {
         userService.registerUser(dto);
         return ResponseEntity.ok("회원가입 완료! 이메일의 링크를 클릭하면 인증이 완료됨");
     }
+
+    @GetMapping("/register/checkEmail")
+    public ResponseEntity<?> checkEmail(
+            @RequestParam ("email") String email
+    ) {
+        boolean isPossibleEmail = !userService.isExistEmail(email);
+        String respMsg = email + "은 " + ((isPossibleEmail) ?
+                "사용 가능한 이메일입니다" : "이미 사용중인 이메일입니다");
+
+        return (isPossibleEmail) ? ResponseEntity.ok(respMsg) : ResponseEntity.badRequest().body(respMsg);
+    }
+
+    @GetMapping("/register/checkName")
+    public ResponseEntity<?> checkName(
+            @RequestParam ("name") String name
+    ) {
+        boolean isPossibleEmail = !userService.isExistUserName(name);
+        String respMsg = name + "은 " + ((isPossibleEmail) ?
+                "사용 가능한 닉네임입니다" : "이미 사용중인 닉네임입니다");
+
+        return (isPossibleEmail) ? ResponseEntity.ok(respMsg) : ResponseEntity.badRequest().body(respMsg);
+    }
+
 
     @PostMapping("/login")
     public ResponseEntity<AuthResponse> login(@RequestBody UserLoginDTO userLoginDTO) {
@@ -86,7 +110,7 @@ public class UserController {
     }
 
     @GetMapping("/profile")
-    public ResponseEntity<?> getUserProfile(@AuthenticationPrincipal com.jandi.plan_backend.security.CustomUserDetails customUserDetails) {
+    public ResponseEntity<?> getUserProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         if (customUserDetails == null) {
             return ResponseEntity.status(401).body(Map.of("error", "로그인이 필요합니다."));
         }
@@ -97,7 +121,7 @@ public class UserController {
 
     @PutMapping("/change-password")
     public ResponseEntity<?> changePassword(
-            @AuthenticationPrincipal com.jandi.plan_backend.security.CustomUserDetails customUserDetails,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody ChangePasswordDTO dto) {
         if (customUserDetails == null) {
             return ResponseEntity.status(401).body(Map.of("error", "로그인이 필요합니다."));
@@ -110,4 +134,6 @@ public class UserController {
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
     }
+
+
 }

--- a/src/main/java/com/jandi/plan_backend/user/controller/preferTripController.java
+++ b/src/main/java/com/jandi/plan_backend/user/controller/preferTripController.java
@@ -1,0 +1,53 @@
+package com.jandi.plan_backend.user.controller;
+
+import com.jandi.plan_backend.user.dto.CityRespDTO;
+import com.jandi.plan_backend.user.dto.ContinentRespDTO;
+import com.jandi.plan_backend.user.dto.CountryRespDTO;
+import com.jandi.plan_backend.user.service.TripService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/trip")
+public class preferTripController {
+    private final TripService tripService;
+
+    public preferTripController(TripService tripService) {
+        this.tripService = tripService;
+    }
+
+    /** 조회 */
+    // 여행 대륙 조회
+    @GetMapping("/continents")
+    public ResponseEntity<List<ContinentRespDTO>> getAllContinents(
+            @RequestParam("filter") List<String> filter
+    ) {
+        List<ContinentRespDTO> allContinents = tripService.getAllContinents(filter);
+        return ResponseEntity.ok(allContinents);
+    }
+
+    // 여행 국가 조회
+    @GetMapping("/countries")
+    public ResponseEntity<List<CountryRespDTO>> getAllCountries(
+            @RequestParam("filter") List<String> filter
+    ) {
+        List<CountryRespDTO> allCountries = tripService.getAllCountries(filter);
+        return ResponseEntity.ok(allCountries);
+    }
+
+    // 여행 도시 조회
+    @GetMapping("/cities")
+    public ResponseEntity<List<CityRespDTO>> getAllCites(
+            @RequestParam("filter") List<String> filter
+    ) {
+        List<CityRespDTO> allCities = tripService.getAllCities(filter);
+        return ResponseEntity.ok(allCities);
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/user/dto/CityRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/user/dto/CityRespDTO.java
@@ -1,0 +1,23 @@
+package com.jandi.plan_backend.user.dto;
+
+import com.jandi.plan_backend.user.entity.MajorDestination;
+import lombok.Getter;
+
+@Getter
+public class CityRespDTO {
+    private Integer destinationId;
+    private String name;
+    private String description;
+    private String imageUrl;
+    private Integer searchCount;
+    private CountryRespDTO country;
+
+    public CityRespDTO(MajorDestination destination) {
+        this.destinationId = destination.getDestinationId();
+        this.name = destination.getName();
+        this.description = destination.getDescription();
+        this.imageUrl = destination.getImageUrl();
+        this.searchCount = destination.getSearchCount();
+        this.country = new CountryRespDTO(destination.getCountry());
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/user/dto/ContinentRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/user/dto/ContinentRespDTO.java
@@ -1,0 +1,19 @@
+package com.jandi.plan_backend.user.dto;
+
+import com.jandi.plan_backend.user.entity.Continent;
+import lombok.Getter;
+
+@Getter
+public class ContinentRespDTO {
+    private Integer continentId;
+    private String name;
+    private String imageUrl;
+    private Integer searchCount;
+
+    public ContinentRespDTO(Continent continent) {
+        this.continentId = continent.getContinentId();
+        this.name = continent.getName();
+        this.imageUrl = continent.getImageUrl();
+        this.searchCount = continent.getSearchCount();
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/user/dto/CountryRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/user/dto/CountryRespDTO.java
@@ -1,0 +1,19 @@
+package com.jandi.plan_backend.user.dto;
+
+import com.jandi.plan_backend.user.entity.Country;
+import lombok.Getter;
+
+@Getter
+public class CountryRespDTO {
+    private Integer countryId;
+    private String name;
+    private Integer searchCount;
+    private ContinentRespDTO continent;
+
+    public CountryRespDTO(Country country) {
+        this.countryId = country.getCountryId();
+        this.name = country.getName();
+        this.searchCount = country.getSearchCount();
+        this.continent = new ContinentRespDTO(country.getContinent());
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/user/entity/Continent.java
+++ b/src/main/java/com/jandi/plan_backend/user/entity/Continent.java
@@ -28,6 +28,13 @@ public class Continent {
     private String name;
 
     /**
+     * 주요 여행지의 이미지 URL.
+     * 최대 길이는 255자로 제한됨.
+     */
+    @Column(length = 255)
+    private String imageUrl;
+
+    /**
      * 대륙 검색 횟수.
      * 검색 시마다 이 값이 증가할 것으로 예상하며, 기본값은 0임.
      */

--- a/src/main/java/com/jandi/plan_backend/user/entity/MajorDestination.java
+++ b/src/main/java/com/jandi/plan_backend/user/entity/MajorDestination.java
@@ -31,6 +31,16 @@ public class MajorDestination {
     private Country country;
 
     /**
+     * 주요 여행지가 속한 대륙(Continent)과의 다대일 관계.
+     * 여러 여행지가 하나의 대륙에 속함.
+     * 데이터베이스 테이블에서는 외래키 "continent_id"를 통해 연결됨.
+     * null 값은 허용되지 않음.
+     */
+    @ManyToOne
+    @JoinColumn(name = "continent_id", nullable = false)
+    private Continent continent;
+
+    /**
      * 주요 여행지의 이름.
      * null 값은 허용되지 않으며, 최대 길이는 100자로 제한됨.
      */

--- a/src/main/java/com/jandi/plan_backend/user/repository/ContinentRepository.java
+++ b/src/main/java/com/jandi/plan_backend/user/repository/ContinentRepository.java
@@ -1,0 +1,12 @@
+package com.jandi.plan_backend.user.repository;
+
+import com.jandi.plan_backend.user.entity.Continent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ContinentRepository extends JpaRepository<Continent, Long> {
+    Optional<Continent> findByName(String continentName);
+    List<Continent> findByNameIn(List<String> filters);
+}

--- a/src/main/java/com/jandi/plan_backend/user/repository/CountryRepository.java
+++ b/src/main/java/com/jandi/plan_backend/user/repository/CountryRepository.java
@@ -1,0 +1,12 @@
+package com.jandi.plan_backend.user.repository;
+
+import com.jandi.plan_backend.user.entity.Country;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CountryRepository extends JpaRepository<Country, Long> {
+    Optional<Object> findByName(String countryName);
+    List<Country> findByNameIn(List<String> filter);
+}

--- a/src/main/java/com/jandi/plan_backend/user/repository/MajorDestinationRepository.java
+++ b/src/main/java/com/jandi/plan_backend/user/repository/MajorDestinationRepository.java
@@ -1,0 +1,13 @@
+package com.jandi.plan_backend.user.repository;
+
+import com.jandi.plan_backend.user.entity.MajorDestination;
+import com.jandi.plan_backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MajorDestinationRepository extends JpaRepository<MajorDestination, Long> {
+    Optional<MajorDestination> findByName(String name);
+    List<MajorDestination> findByNameIn(List<String> filter);
+}

--- a/src/main/java/com/jandi/plan_backend/user/repository/MajorDestinationRepository.java
+++ b/src/main/java/com/jandi/plan_backend/user/repository/MajorDestinationRepository.java
@@ -1,7 +1,6 @@
 package com.jandi.plan_backend.user.repository;
 
 import com.jandi.plan_backend.user.entity.MajorDestination;
-import com.jandi.plan_backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/jandi/plan_backend/user/service/TripService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/TripService.java
@@ -1,0 +1,163 @@
+package com.jandi.plan_backend.user.service;
+
+import com.jandi.plan_backend.storage.dto.ImageResponseDto;
+import com.jandi.plan_backend.storage.service.ImageService;
+import com.jandi.plan_backend.user.dto.CityRespDTO;
+import com.jandi.plan_backend.user.dto.ContinentRespDTO;
+import com.jandi.plan_backend.user.dto.CountryRespDTO;
+import com.jandi.plan_backend.user.entity.Continent;
+import com.jandi.plan_backend.user.entity.Country;
+import com.jandi.plan_backend.user.entity.MajorDestination;
+import com.jandi.plan_backend.user.entity.User;
+import com.jandi.plan_backend.user.repository.ContinentRepository;
+import com.jandi.plan_backend.user.repository.CountryRepository;
+import com.jandi.plan_backend.user.repository.MajorDestinationRepository;
+import com.jandi.plan_backend.util.ValidationUtil;
+import com.jandi.plan_backend.util.service.BadRequestExceptionMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class TripService {
+    private final ContinentRepository continentRepository;
+    private final CountryRepository countryRepository;
+    private final MajorDestinationRepository majorDestinationRepository;
+    private final ValidationUtil validationUtil;
+    private final ImageService imageService;
+
+    public TripService(ContinentRepository continentRepository, CountryRepository countryRepository, MajorDestinationRepository majorDestinationRepository, ValidationUtil validationUtil, ImageService imageService) {
+        this.continentRepository = continentRepository;
+        this.countryRepository = countryRepository;
+        this.majorDestinationRepository = majorDestinationRepository;
+        this.validationUtil = validationUtil;
+        this.imageService = imageService;
+    }
+
+    /** 조회 관련 */
+    // 대륙 조회
+    public List<ContinentRespDTO> getAllContinents(List<String> filter) {
+        List<Continent> continents = (filter.isEmpty()) ?
+                continentRepository.findAll() :
+                continentRepository.findByNameIn(filter);
+
+        return continents.stream()
+                .map(ContinentRespDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    // 국가 조회
+    public List<CountryRespDTO> getAllCountries(List<String> filter) {
+        List<Country> countries = (filter.isEmpty()) ?
+                countryRepository.findAll() :
+                countryRepository.findByNameIn(filter);
+
+        return countries.stream()
+                .map(CountryRespDTO::new)
+                .collect(Collectors.toList());
+    }
+
+    // 도시 조회
+    public List<CityRespDTO> getAllCities(List<String> filter) {
+        List<MajorDestination> cities = (filter.isEmpty()) ?
+                majorDestinationRepository.findAll() :
+                majorDestinationRepository.findByNameIn(filter);
+
+        return cities.stream()
+                .map(CityRespDTO::new)
+                .collect(Collectors.toList());
+    }
+
+
+    /** 생성 관련 */
+    //대륙 생성: 디버깅용, 실제 서비스 중엔 대륙이 추가될 것 같지 않음!
+    public Continent createNewContinent(
+            String userEmail, String continentName, MultipartFile file) {
+        //유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserIsAdmin(user);
+
+        //대륙 검증: 이미 존재한다면 추가 생성하지 않음
+        if (continentRepository.findByName(continentName).isPresent()) {
+            throw new BadRequestExceptionMessage("이미 존재하는 대륙입니다.");
+        }
+        Continent continent = new Continent();
+        continent.setName(continentName);
+        continentRepository.save(continent);
+
+        //이미지 업로드 및 반영
+        ImageResponseDto imageDTO = imageService.uploadImage(
+                file, userEmail, continent.getContinentId(), "continent");
+        continent.setImageUrl(imageDTO.getImageUrl());
+
+        continentRepository.save(continent);
+        return continent;
+    }
+
+
+    //국가 생성
+    public Country createNewCountry(
+            String userEmail, String continentName, String countryName) {
+        //유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserIsAdmin(user);
+
+        //대륙 검증
+        Continent continent = validationUtil.validateContinentExists(continentName);
+
+        //국가 검증: 이미 존재한다면 추가 생성하지 않음
+        if (countryRepository.findByName(countryName).isPresent()) {
+            throw new BadRequestExceptionMessage("이미 존재하는 국가입니다.");
+        }
+
+        //국가 생성
+        Country newCountry = new Country();
+        newCountry.setName(countryName);
+        newCountry.setContinent(continent);
+        countryRepository.save(newCountry);
+
+        return newCountry;
+    }
+
+    // 도시 생성
+    public MajorDestination createNewCity(
+            String userEmail, String countryName, String cityName, String description, MultipartFile file) {
+        //유저 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserIsAdmin(user);
+        log.info("user: {}", user);
+
+        //국가 검증
+        Country country = validationUtil.validateCountryExists(countryName);
+        log.info("country: {}", country);
+
+        //도시 검증: 이미 존재한다면 추가 생성하지 않음
+        if (majorDestinationRepository.findByName(cityName).isPresent()) {
+            throw new BadRequestExceptionMessage("이미 존재하는 도시입니다.");
+        }
+
+        //도시 생성
+        MajorDestination newCity = new MajorDestination();
+        newCity.setName(cityName);
+        newCity.setCountry(country);
+        newCity.setContinent(country.getContinent());
+        newCity.setDescription(description);
+
+        majorDestinationRepository.save(newCity);
+        log.info("newCity: {}", newCity);
+
+        //이미지 업로드 및 반영
+        ImageResponseDto imageDTO = imageService.uploadImage(
+                file, userEmail, newCity.getDestinationId(), "majorDestination");
+        newCity.setImageUrl(imageDTO.getImageUrl());
+        log.info("imageDTO: {}", imageDTO);
+
+        majorDestinationRepository.save(newCity);
+
+        return newCity;
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/user/service/UserService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/UserService.java
@@ -178,4 +178,12 @@ public class UserService {
         user.setUpdatedAt(LocalDateTime.now());
         userRepository.save(user);
     }
+
+    public boolean isExistEmail(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
+
+    public boolean isExistUserName(String userName) {
+        return userRepository.findByUserName(userName).isPresent();
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -8,8 +8,15 @@ import com.jandi.plan_backend.resource.entity.Banner;
 import com.jandi.plan_backend.resource.entity.Notice;
 import com.jandi.plan_backend.resource.repository.BannerRepository;
 import com.jandi.plan_backend.resource.repository.NoticeRepository;
+import com.jandi.plan_backend.resource.service.BannerService;
 import com.jandi.plan_backend.resource.service.NoticeService;
+import com.jandi.plan_backend.user.entity.Continent;
+import com.jandi.plan_backend.user.entity.Country;
+import com.jandi.plan_backend.user.entity.MajorDestination;
 import com.jandi.plan_backend.user.entity.User;
+import com.jandi.plan_backend.user.repository.ContinentRepository;
+import com.jandi.plan_backend.user.repository.CountryRepository;
+import com.jandi.plan_backend.user.repository.MajorDestinationRepository;
 import com.jandi.plan_backend.user.repository.UserRepository;
 import com.jandi.plan_backend.util.service.BadRequestExceptionMessage;
 import org.springframework.stereotype.Component;
@@ -24,13 +31,19 @@ public class ValidationUtil {
     private final CommentRepository commentRepository;
     private final BannerRepository bannerRepository;
     private final NoticeRepository noticeRepository;
+    private final ContinentRepository continentRepository;
+    private final CountryRepository countryRepository;
+    private final MajorDestinationRepository majorDestinationRepository;
 
-    public ValidationUtil(UserRepository userRepository, CommunityRepository communityRepository, CommentRepository commentRepository, BannerRepository bannerRepository, NoticeRepository noticeRepository) {
+    public ValidationUtil(UserRepository userRepository, CommunityRepository communityRepository, CommentRepository commentRepository, BannerRepository bannerRepository, NoticeRepository noticeRepository, ContinentRepository continentRepository, CountryRepository countryRepository, MajorDestinationRepository majorDestinationRepository) {
         this.userRepository = userRepository;
         this.communityRepository = communityRepository;
         this.commentRepository = commentRepository;
         this.bannerRepository = bannerRepository;
         this.noticeRepository = noticeRepository;
+        this.continentRepository = continentRepository;
+        this.countryRepository = countryRepository;
+        this.majorDestinationRepository = majorDestinationRepository;
     }
 
     /** userRepository */
@@ -96,5 +109,24 @@ public class ValidationUtil {
     public Notice validateNoticeExists(Integer noticeId) {
         return (Notice) noticeRepository.findByNoticeId(noticeId)
                 .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 공지입니다."));
+    }
+
+    /** Prefer Continent/Country/Destination Repository 관련 검증 */
+    //대륙 관련
+    public Continent validateContinentExists(String continentName) {
+        return (Continent) continentRepository.findByName(continentName)
+                .orElseThrow(() -> new BadRequestExceptionMessage("등록되지 않은 대륙입니다."));
+    }
+
+    //국가 관련
+    public Country validateCountryExists(String countryName) {
+        return (Country) countryRepository.findByName(countryName)
+                .orElseThrow(() -> new BadRequestExceptionMessage("등록되지 않은 국가입니다."));
+    }
+
+    //도시 관련
+    public MajorDestination validateCityExists(String cityName) {
+        return (MajorDestination) majorDestinationRepository.findByName(cityName)
+                .orElseThrow(() -> new BadRequestExceptionMessage("등록되지 않은 도시입니다."));
     }
 }


### PR DESCRIPTION
## 작업 내용
- 여행지 관련 DB(`Continent`, `Country`, `MajorDestination`)에 이미지를 포함한 데이터 모두 추가
- 여행지 관련 DB 조회 API 추가
- 여행지 관련 DB 생성 API 추가
- 닉네임 중복확인 API 추가
- 이메일 중복확인 API 추가

## 전달 사항
- 주요 여행지 설명을 지역 이름 대신 어떤 국가의 주요 여행지인지로 저장
-> 예) 도쿄에 대한 설명: '도쿄의 주요 여행지' 대신 '일본의 주요 여행지'로 변경
- `image` 엔티티에서 `targetType`: 도시에 대한 이미지는 `majorDestination`로, 대륙에 대한 이미지는 `continent`로 저장
- 조회수 카운팅은 특정 게시물을 조회했을 때, 즉 `GET /api/community/posts/{postId}` 호출할 때마다 증가되도록 `getSpecPost` 메서드 수정