### PR TITLE
Feat: 여행 플랜 관련 API 추가

### DIFF
--- a/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -89,7 +90,7 @@ public class CommentService {
         comment.setCommunity(post);
         comment.setParentComment(parentComment);
         comment.setUserId(user.getUserId());
-        comment.setCreatedAt(LocalDateTime.now());
+        comment.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         comment.setContents(content);
         comment.setLikeCount(0);
         comment.setRepliesCount(0);

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import com.jandi.plan_backend.util.service.PaginationService;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,7 +75,7 @@ public class PostService {
         community.setUser(user);
         community.setTitle(postDTO.getTitle());
         community.setContents(postDTO.getContent());
-        community.setCreatedAt(LocalDateTime.now());
+        community.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         community.setLikeCount(0);
         community.setCommentCount(0);
 

--- a/src/main/java/com/jandi/plan_backend/image/service/ImageService.java
+++ b/src/main/java/com/jandi/plan_backend/image/service/ImageService.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 @Slf4j
@@ -44,7 +45,7 @@ public class ImageService {
         image.setTargetId(targetId);
         image.setImageUrl(storedFileName);
         image.setOwner(owner);
-        image.setCreatedAt(LocalDateTime.now());
+        image.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         image = imageRepository.save(image);
         String fullPublicUrl = publicUrlPrefix + image.getImageUrl();
         ImageRespDto responseDto = new ImageRespDto();
@@ -104,7 +105,7 @@ public class ImageService {
         }
         String newStoredFileName = uploadResult.replace("파일 업로드 성공: ", "").trim();
         image.setImageUrl(newStoredFileName);
-        image.setCreatedAt(LocalDateTime.now());
+        image.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         image = imageRepository.save(image);
         String fullPublicUrl = publicUrlPrefix + image.getImageUrl();
         ImageRespDto responseDto = new ImageRespDto();

--- a/src/main/java/com/jandi/plan_backend/resource/service/BannerService.java
+++ b/src/main/java/com/jandi/plan_backend/resource/service/BannerService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -50,7 +51,7 @@ public class BannerService {
 
         //배너글 생성
         Banner banner = new Banner();
-        banner.setCreatedAt(LocalDateTime.now());
+        banner.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         banner.setTitle(title);
         banner.setLinkUrl(link);
         bannerRepository.save(banner); //imageUrl 미포함된 상태로 1차 저장

--- a/src/main/java/com/jandi/plan_backend/resource/service/BannerService.java
+++ b/src/main/java/com/jandi/plan_backend/resource/service/BannerService.java
@@ -1,5 +1,6 @@
 package com.jandi.plan_backend.resource.service;
 
+import com.jandi.plan_backend.image.entity.Image;
 import com.jandi.plan_backend.resource.dto.BannerListDTO;
 import com.jandi.plan_backend.resource.dto.BannerRespDTO;
 import com.jandi.plan_backend.resource.entity.Banner;
@@ -14,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -98,6 +100,8 @@ public class BannerService {
         Banner banner = validationUtil.validateBannerExists(bannerId);
 
         //배너 삭제 및 반환
+        imageRepository.findByTargetTypeAndTargetId("banner", bannerId)
+                .ifPresent(imageRepository::delete); //기존 이미지 삭제
         bannerRepository.delete(banner);
         return true;
     }

--- a/src/main/java/com/jandi/plan_backend/resource/service/NoticeService.java
+++ b/src/main/java/com/jandi/plan_backend/resource/service/NoticeService.java
@@ -9,6 +9,7 @@ import com.jandi.plan_backend.util.ValidationUtil;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -36,7 +37,7 @@ public class NoticeService {
 
         // 공지글 생성
         Notice notice = new Notice();
-        notice.setCreatedAt(LocalDateTime.now());
+        notice.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         notice.setTitle(noticeDTO.getTitle());
         notice.setContents(noticeDTO.getContents());
 

--- a/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
+++ b/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
@@ -2,6 +2,7 @@ package com.jandi.plan_backend.trip.controller;
 
 import com.jandi.plan_backend.security.JwtTokenProvider;
 import com.jandi.plan_backend.trip.dto.MyTripRespDTO;
+import com.jandi.plan_backend.trip.dto.TripLikeRespDTO;
 import com.jandi.plan_backend.trip.dto.TripRespDTO;
 import com.jandi.plan_backend.trip.service.TripService;
 import org.springframework.data.domain.Page;
@@ -107,6 +108,20 @@ public class TripController {
         TripRespDTO savedTrip = tripService.writeTrip(
                 userEmail, title, description, startDate, endDate, isPrivate, image);
         return ResponseEntity.ok(savedTrip);
+    }
+
+    /** 타인의 여행 계획을 '좋아요' 목록에 추가 */
+    @PostMapping("/like/{tripId}")
+    public ResponseEntity<?> likeTrip(
+            @PathVariable Integer tripId,
+            @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        TripLikeRespDTO likedTrip = tripService.addLikeTrip(userEmail, tripId);
+        return ResponseEntity.ok(likedTrip);
     }
 
 }

--- a/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
+++ b/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
@@ -67,6 +67,30 @@ public class TripController {
         );
     }
 
+    /** 좋아요한 여행 계획 목록 조회 */
+    @GetMapping("/my/likedTrips")
+    public Map<String, Object> getLikedTrips(
+            @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        Page<TripRespDTO> likedTripsPage = tripService.getLikedTrips(userEmail, page, size);
+
+        return Map.of(
+                "pageInfo", Map.of(
+                        "currentPage", likedTripsPage.getNumber(),
+                        "currentSize", likedTripsPage.getContent().size(),
+                        "totalPages", likedTripsPage.getTotalPages(),
+                        "totalSize", likedTripsPage.getTotalElements()
+                ),
+                "items", likedTripsPage.getContent()
+        );
+    }
+
     /** 개별 여행 계획 조회
      * 공개로 설정된 다른 유저의 여행 계획 + 공개/비공개 설정된 본인의 여행 계획만 조회 가능
      * 아직 친구 기능은 구현되지 않아 이 부분은 아직 제외한 채로 구현
@@ -111,7 +135,7 @@ public class TripController {
     }
 
     /** 타인의 여행 계획을 '좋아요' 목록에 추가 */
-    @PostMapping("/like/{tripId}")
+    @PostMapping("/my/likedTrips/{tripId}")
     public ResponseEntity<?> likeTrip(
             @PathVariable Integer tripId,
             @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기

--- a/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
+++ b/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
@@ -24,6 +24,7 @@ public class TripController {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
+    /** 전체 유저의 여행 계획 목록 조회 (공개 설정된 것만 조회) */
     @GetMapping("/allTrips")
     public Map<String, Object> getAllTrips(
             @RequestParam(defaultValue = "0") int page,
@@ -42,6 +43,7 @@ public class TripController {
         );
     }
 
+    /** 내 여행 계획 목록 조회 (본인 명의의 계획만 조회) */
     @GetMapping("/my/allTrips")
     public Map<String, Object> getAllMyTrips(
             @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기
@@ -65,6 +67,7 @@ public class TripController {
         );
     }
 
+    /** 여행 계획 생성 */
     @PostMapping("/my/create")
     public ResponseEntity<?> writeTrip(
             @RequestHeader("Authorization") String token, // 헤더의 Authorization에서 JWT 토큰 받기

--- a/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
+++ b/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
@@ -1,12 +1,11 @@
 package com.jandi.plan_backend.trip.controller;
 
-import com.jandi.plan_backend.commu.dto.CommentReqDTO;
-import com.jandi.plan_backend.commu.dto.CommentRespDTO;
 import com.jandi.plan_backend.security.JwtTokenProvider;
 import com.jandi.plan_backend.trip.dto.MyTripRespDTO;
 import com.jandi.plan_backend.trip.dto.TripRespDTO;
 import com.jandi.plan_backend.trip.service.TripService;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -65,6 +64,28 @@ public class TripController {
                 ),
                 "items", myTripsPage.getContent()
         );
+    }
+
+    /** 개별 여행 계획 조회
+     * 공개로 설정된 다른 유저의 여행 계획 + 공개/비공개 설정된 본인의 여행 계획만 조회 가능
+     * 아직 친구 기능은 구현되지 않아 이 부분은 아직 제외한 채로 구현
+     */
+    @GetMapping("/{tripId}")
+    public ResponseEntity<?> getSpecTrips(
+            @PathVariable Integer tripId,
+            @RequestHeader(value = "Authorization", required = false) String token // 헤더의 Authorization에서 JWT 토큰 받기
+    ){
+        if(token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("로그인이 필요합니다.");
+        }
+
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(tripService.getSpecTrips(userEmail, tripId));
     }
 
     /** 여행 계획 생성 */

--- a/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
+++ b/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
@@ -136,7 +136,7 @@ public class TripController {
 
     /** 타인의 여행 계획을 '좋아요' 목록에 추가 */
     @PostMapping("/my/likedTrips/{tripId}")
-    public ResponseEntity<?> likeTrip(
+    public ResponseEntity<?> addLikeTrip(
             @PathVariable Integer tripId,
             @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
     ){
@@ -148,4 +148,19 @@ public class TripController {
         return ResponseEntity.ok(likedTrip);
     }
 
+    /** 타인의 여행 계획을 '좋아요' 목록에서 삭제 */
+    @DeleteMapping("/my/likedTrips/{tripId}")
+    public ResponseEntity<?> deleteLikeTrip(
+            @PathVariable Integer tripId,
+            @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
+    ){
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        boolean isDeleteLikeTrip = tripService.deleteLikeTrip(userEmail, tripId);
+        return (isDeleteLikeTrip) ?
+                ResponseEntity.status(HttpStatus.OK).body("좋아요 해제되었습니다.") :
+                ResponseEntity.status(HttpStatus.BAD_REQUEST).body("알 수 없는 문제가 발생했습니다. 잠시 후 다시 시도해주세요!");
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/trip/dto/MyTripRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/trip/dto/MyTripRespDTO.java
@@ -1,5 +1,7 @@
 package com.jandi.plan_backend.trip.dto;
 
+import com.jandi.plan_backend.trip.entity.Trip;
+import com.jandi.plan_backend.user.entity.User;
 import lombok.Getter;
 import java.time.LocalDate;
 
@@ -15,5 +17,10 @@ public class MyTripRespDTO extends TripRespDTO {
                          String description, Integer likeCount, String imageUrl, Boolean privatePlan) {
         super(user, tripId, title, startDate, endDate, description, likeCount, imageUrl);
         this.privatePlan = privatePlan;
+    }
+
+    public MyTripRespDTO(User user, String userProfileUrl, Trip trip, String TripImageUrl){
+        super(user, userProfileUrl, trip, TripImageUrl);
+        this.privatePlan = trip.getPrivatePlan();
     }
 }

--- a/src/main/java/com/jandi/plan_backend/trip/dto/TripLikeRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/trip/dto/TripLikeRespDTO.java
@@ -1,0 +1,16 @@
+package com.jandi.plan_backend.trip.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class TripLikeRespDTO {
+    private MyTripRespDTO trip;
+    private LocalDateTime likedAt;
+
+    public TripLikeRespDTO(MyTripRespDTO trip, LocalDateTime likedAt) {
+        this.trip = trip;
+        this.likedAt = likedAt;
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/trip/dto/TripRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/trip/dto/TripRespDTO.java
@@ -1,5 +1,7 @@
 package com.jandi.plan_backend.trip.dto;
 
+import com.jandi.plan_backend.trip.entity.Trip;
+import com.jandi.plan_backend.user.entity.User;
 import lombok.Getter;
 import java.time.LocalDate;
 
@@ -28,5 +30,16 @@ public class TripRespDTO {
         this.description = description;
         this.likeCount = likeCount;
         this.imageUrl = imageUrl;
+    }
+
+    public TripRespDTO(User user, String userProfileUrl, Trip trip, String TripImageUrl){
+        this.user = new UserTripDTO(user.getUserId(), user.getUserName(), userProfileUrl);
+        this.tripId = trip.getTripId();
+        this.title = trip.getTitle();
+        this.startDate = trip.getStartDate();
+        this.endDate = trip.getEndDate();
+        this.description = trip.getDescription();
+        this.likeCount = trip.getLikeCount();
+        this.imageUrl = TripImageUrl;
     }
 }

--- a/src/main/java/com/jandi/plan_backend/trip/entity/Trip.java
+++ b/src/main/java/com/jandi/plan_backend/trip/entity/Trip.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import com.jandi.plan_backend.user.entity.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 /**
  * 엔티티 클래스. "trip" 테이블에 매핑됨.
@@ -58,4 +59,21 @@ public class Trip {
 
     @Column(nullable = false)
     private Integer likeCount;
+
+    public Trip(User user, String title, String description, Boolean privatePlan,
+                LocalDate startDate, LocalDate endDate) {
+        this.user = user;
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.privatePlan = privatePlan;
+        this.likeCount = 0;
+    }
+
+    public Trip() {
+
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/trip/repository/TripLikeRepository.java
+++ b/src/main/java/com/jandi/plan_backend/trip/repository/TripLikeRepository.java
@@ -4,6 +4,8 @@ import com.jandi.plan_backend.trip.entity.Trip;
 import com.jandi.plan_backend.trip.entity.TripLike;
 import com.jandi.plan_backend.trip.entity.TripLikeId;
 import com.jandi.plan_backend.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -11,4 +13,10 @@ import java.util.Optional;
 public interface TripLikeRepository extends JpaRepository<TripLike, TripLikeId> {
     //특정 유저가 특정 여행계획을 좋아요했는지 검색
     Optional<TripLike> findByTripAndUser(Trip trip, User user);
+
+    //특정 유저가 좋아요한 여행 계획 조회
+    Page<Object> findByUser(User user, Pageable pageable);
+
+    //특정 유저가 좋아요한 여행 계획 갯수 반환
+    long countByUser(User user);
 }

--- a/src/main/java/com/jandi/plan_backend/trip/repository/TripLikeRepository.java
+++ b/src/main/java/com/jandi/plan_backend/trip/repository/TripLikeRepository.java
@@ -1,7 +1,14 @@
 package com.jandi.plan_backend.trip.repository;
 
+import com.jandi.plan_backend.trip.entity.Trip;
 import com.jandi.plan_backend.trip.entity.TripLike;
+import com.jandi.plan_backend.trip.entity.TripLikeId;
+import com.jandi.plan_backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TripLikeRepository extends JpaRepository<TripLike, Long> {
+import java.util.Optional;
+
+public interface TripLikeRepository extends JpaRepository<TripLike, TripLikeId> {
+    //특정 유저가 특정 여행계획을 좋아요했는지 검색
+    Optional<TripLike> findByTripAndUser(Trip trip, User user);
 }

--- a/src/main/java/com/jandi/plan_backend/trip/repository/TripLikeRepository.java
+++ b/src/main/java/com/jandi/plan_backend/trip/repository/TripLikeRepository.java
@@ -1,0 +1,7 @@
+package com.jandi.plan_backend.trip.repository;
+
+import com.jandi.plan_backend.trip.entity.TripLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripLikeRepository extends JpaRepository<TripLike, Long> {
+}

--- a/src/main/java/com/jandi/plan_backend/trip/repository/TripRepository.java
+++ b/src/main/java/com/jandi/plan_backend/trip/repository/TripRepository.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TripRepository extends JpaRepository<Trip, Long> {
+    //tripId와 일치하는 여행 계획 반환
+    Optional<Object> findByTripId(Integer tripId);
+
     // 유저가 작성한 여행 계획 목록을 반환
     List<Trip> findByUserEquals(User user);
 

--- a/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
+++ b/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
@@ -89,9 +89,7 @@ public class TripService {
                 });
     }
 
-    /**
-     * 개별 여행 계획 조회
-     */
+    /** 개별 여행 계획 조회 */
     public MyTripRespDTO getSpecTrips(String userEmail, Integer tripId) {
         //여행 계획 검증
         Trip trip = validationUtil.validateTripExists(tripId);
@@ -174,6 +172,8 @@ public class TripService {
         //좋아요 가능 여부 검증: 본인의 여행계획인 경우 블락처리
         if(trip.getUser().getUserId().equals(user.getUserId())) {
             throw new BadRequestExceptionMessage("본인의 여행계획은 좋아요할 수 없습니다.");
+        }else if(tripLikeRepository.findByTripAndUser(trip, user).isPresent()) {
+            throw new BadRequestExceptionMessage("이미 좋아요한 여행계획입니다.");
         }
 
         //좋아요 리스트에 추가

--- a/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
+++ b/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
@@ -183,6 +183,10 @@ public class TripService {
         tripLike.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         tripLikeRepository.save(tripLike);
 
+        //좋아요 수 업데이트
+        trip.setLikeCount(trip.getLikeCount() + 1);
+        tripRepository.save(trip);
+
         //DTO 생성 및 반환
         Optional<Image> userProfile = imageService.getImageByTarget("userProfile", user.getUserId());
         String userProfileUrl = userProfile.map(Image::getImageUrl).orElse(null);

--- a/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
+++ b/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
@@ -159,8 +159,8 @@ public class TripService {
         trip.setStartDate(LocalDate.parse(startDate));
         trip.setEndDate(LocalDate.parse(endDate));
         trip.setUser(user);
-        trip.setCreatedAt(LocalDateTime.now());
-        trip.setUpdatedAt(LocalDateTime.now());
+        trip.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+        trip.setUpdatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         trip.setLikeCount(0);
         trip.setPrivatePlan(isPrivate);
         tripRepository.save(trip);

--- a/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
+++ b/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
@@ -223,4 +223,30 @@ public class TripService {
         MyTripRespDTO myTripRespDTO = new MyTripRespDTO(user, userProfileUrl, trip, tripImageUrl);
         return new TripLikeRespDTO(myTripRespDTO, tripLike.getCreatedAt());
     }
+
+    /** 좋아요 리스트에서 삭제 */
+    public boolean deleteLikeTrip(String userEmail, Integer tripId) {
+        boolean result = false;
+
+        //유저 및 여행 계획 검증
+        User user = validationUtil.validateUserExists(userEmail);
+        Trip trip = validationUtil.validateTripExists(tripId);
+
+        //좋아요 검증: 좋아요하지 않은 여행계획일 경우 블락처리
+        Optional<TripLike> tripLike = tripLikeRepository.findByTripAndUser(trip, user);
+        if(tripLike.isEmpty()) {
+            throw new BadRequestExceptionMessage("이미 좋아요 해제되어 있습니다.");
+        }else{
+            //좋아요 리스트에서 삭제
+            tripLikeRepository.delete(tripLike.get());
+
+            //좋아요 수 업데이트
+            trip.setLikeCount(trip.getLikeCount() - 1);
+            tripRepository.save(trip);
+
+            result = true;
+        }
+
+        return result;
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/user/service/UserCleanupService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/UserCleanupService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Slf4j
@@ -27,7 +28,7 @@ public class UserCleanupService {
     @Scheduled(cron = "0 0 * * * *")  // 매 정각 실행 (원하는 주기로 수정 가능)
     @Transactional
     public void cleanupUnverifiedUsers() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         List<User> unverifiedUsers = userRepository.findByVerifiedFalseAndTokenExpiresBefore(now);
         if (!unverifiedUsers.isEmpty()) {
             log.info("삭제할 미인증 사용자 {}명을 찾았습니다.", unverifiedUsers.size());

--- a/src/main/java/com/jandi/plan_backend/user/service/UserService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/UserService.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -57,13 +58,13 @@ public class UserService {
         user.setLastName(dto.getLastName());
         user.setEmail(dto.getEmail());
         user.setPassword(passwordEncoder.encode(dto.getPassword()));
-        user.setCreatedAt(LocalDateTime.now());
-        user.setUpdatedAt(LocalDateTime.now());
+        user.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+        user.setUpdatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         user.setVerified(false);
         user.setReported(false);
         String token = UUID.randomUUID().toString();
         user.setVerificationToken(token);
-        user.setTokenExpires(LocalDateTime.now().plusHours(24));
+        user.setTokenExpires(LocalDateTime.now(ZoneId.of("Asia/Seoul")).plusHours(24));
         userRepository.save(user);
         String verifyLink = verifyUrl + "?token=" + token;
         String subject = "[회원가입] 이메일 인증 안내";
@@ -121,13 +122,13 @@ public class UserService {
             return false;
         }
         User user = optionalUser.get();
-        if (user.getTokenExpires() != null && user.getTokenExpires().isBefore(LocalDateTime.now())) {
+        if (user.getTokenExpires() != null && user.getTokenExpires().isBefore(LocalDateTime.now(ZoneId.of("Asia/Seoul")))) {
             return false;
         }
         user.setVerified(true);
         user.setVerificationToken(null);
         user.setTokenExpires(null);
-        user.setUpdatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         userRepository.save(user);
         return true;
     }
@@ -140,7 +141,7 @@ public class UserService {
         User user = optionalUser.get();
         String tempPassword = UUID.randomUUID().toString().substring(0, 8);
         user.setPassword(passwordEncoder.encode(tempPassword));
-        user.setUpdatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         userRepository.save(user);
         String subject = "[비밀번호 찾기] 임시 비밀번호 안내";
         String text = "임시 비밀번호: " + tempPassword + "\n로그인 후 반드시 비밀번호를 변경하세요.";
@@ -177,7 +178,7 @@ public class UserService {
             throw new RuntimeException("현재 비밀번호가 올바르지 않습니다.");
         }
         user.setPassword(passwordEncoder.encode(dto.getNewPassword()));
-        user.setUpdatedAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         userRepository.save(user);
     }
 

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -69,7 +69,7 @@ public class ValidationUtil {
     // 사용자 활동 제한 여부 검증
     public void validateUserRestricted(User user) {
         if (user.getReported()) {
-            throw new BadRequestExceptionMessage("비정상적인 활동이 반복되어 게시글 작성이 제한되었습니다.");
+            throw new BadRequestExceptionMessage("비정상적인 활동이 반복되어 일부 기능 사용이 제한되었습니다.");
         }
     }
 

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -8,6 +8,8 @@ import com.jandi.plan_backend.resource.entity.Banner;
 import com.jandi.plan_backend.resource.entity.Notice;
 import com.jandi.plan_backend.resource.repository.BannerRepository;
 import com.jandi.plan_backend.resource.repository.NoticeRepository;
+import com.jandi.plan_backend.trip.entity.Trip;
+import com.jandi.plan_backend.trip.repository.TripRepository;
 import com.jandi.plan_backend.user.entity.City;
 import com.jandi.plan_backend.user.entity.Continent;
 import com.jandi.plan_backend.user.entity.Country;
@@ -33,8 +35,14 @@ public class ValidationUtil {
     private final ContinentRepository continentRepository;
     private final CountryRepository countryRepository;
     private final CityRepository cityRepository;
+    private final TripRepository tripRepository;
 
-    public ValidationUtil(UserRepository userRepository, CommunityRepository communityRepository, CommentRepository commentRepository, BannerRepository bannerRepository, NoticeRepository noticeRepository, ContinentRepository continentRepository, CountryRepository countryRepository, CityRepository cityRepository) {
+    public ValidationUtil(
+            UserRepository userRepository, CommunityRepository communityRepository,
+            CommentRepository commentRepository, BannerRepository bannerRepository,
+            NoticeRepository noticeRepository, ContinentRepository continentRepository,
+            CountryRepository countryRepository, CityRepository cityRepository,
+            TripRepository tripRepository) {
         this.userRepository = userRepository;
         this.communityRepository = communityRepository;
         this.commentRepository = commentRepository;
@@ -43,6 +51,7 @@ public class ValidationUtil {
         this.continentRepository = continentRepository;
         this.countryRepository = countryRepository;
         this.cityRepository = cityRepository;
+        this.tripRepository = tripRepository;
     }
 
     /** userRepository */
@@ -105,6 +114,7 @@ public class ValidationUtil {
 
 
     /** NoticeRepository 관련 검증 */
+    //공지사항의 존재 여부 검증
     public Notice validateNoticeExists(Integer noticeId) {
         return (Notice) noticeRepository.findByNoticeId(noticeId)
                 .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 공지입니다."));
@@ -127,6 +137,13 @@ public class ValidationUtil {
     public City validateCityExists(String cityName) {
         return (City) cityRepository.findByName(cityName)
                 .orElseThrow(() -> new BadRequestExceptionMessage("등록되지 않은 도시입니다."));
+    }
+
+    /** TripRepository 관련 검증 */
+    //여행 계획의 존재 여부 검증
+    public Trip validateTripExists(Integer tripId) {
+        return (Trip) tripRepository.findByTripId(tripId)
+                .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 여행 계획입니다."));
     }
 
     /** 기타 검증 유틸 */

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -146,11 +146,15 @@ public class ValidationUtil {
                 .orElseThrow(() -> new BadRequestExceptionMessage("존재하지 않는 여행 계획입니다."));
     }
 
-    /** 기타 검증 유틸 */
+    /**
+     * 기타 검증 유틸
+     *
+     * @return
+     */
     //날짜 검증: YYYY-MM-DD인지 검증
-    public void ValidateDate(String date){
+    public LocalDate ValidateDate(String date){
         try {
-            LocalDate.parse(date);
+            return LocalDate.parse(date);
         }catch (Exception e){
             throw new BadRequestExceptionMessage("날짜 형식에 문제가 있습니다. 다시 한번 확인해주세요");
         }


### PR DESCRIPTION
## 작업 내용
- 개별 여행 계획 조회 API 작성 (API 명세서 링크)
- 여행 계획 좋아요 추가 API 작성 (API 명세서 링크)
- 여행 계획 좋아요에서 삭제 API 작성 (API 명세서 링크)
- 좋아요한 여행 계획 목록 조회 API 작성 (API 명세서 링크)

## 전달 사항
- 날짜 형식을 KST로 통일
- TripService: image 전치사를 urlPrefix라는 별도의 변수로 저장
- TripRespDTO에 별도의 생성자를 만들어 TripService에서 TripRespDTO를 반환할 때 더 간결히 표현되도록 함
- Trip 엔티티에 별도의 생성자를 만들어 TripService의 writeTrip 메소드에서 새 여행 계획을 생성할 때 더 간결히 표현되도록 함