### PR TITLE
 Feat: 신고된 댓글/게시글 조회 기능 추가

### DIFF
--- a/src/main/java/com/jandi/plan_backend/commu/controller/ManageCommunityController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/ManageCommunityController.java
@@ -1,0 +1,52 @@
+package com.jandi.plan_backend.commu.controller;
+
+import com.jandi.plan_backend.commu.dto.CommunityListDTO;
+import com.jandi.plan_backend.commu.dto.CommunityReportedListDTO;
+import com.jandi.plan_backend.commu.service.ManageCommunityService;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/manage/community")
+public class ManageCommunityController {
+    private final ManageCommunityService manageCommunityService;
+
+    public ManageCommunityController(ManageCommunityService manageCommunityService) {
+        this.manageCommunityService = manageCommunityService;
+    }
+
+
+    /** reported 조회 */
+    // 신고 게시물 조회
+    @GetMapping("/reported/posts")
+    public ResponseEntity<Map<String, Object>> getReportedPosts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        if(userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "로그인이 필요합니다."));
+        }
+        String userEmail = userDetails.getUsername();
+
+        Page<CommunityReportedListDTO> reportedPosts = manageCommunityService.getReportedPosts(userEmail, page, size);
+
+        Map<String, Object> response = Map.of(
+                "pageInfo", Map.of(
+                        "currentPage", reportedPosts.getNumber(),
+                        "currentSize", reportedPosts.getContent().size(),
+                        "totalPages", reportedPosts.getTotalPages(),
+                        "totalSize", reportedPosts.getTotalElements()
+                ),
+                "items", reportedPosts.getContent()
+        );
+
+        return ResponseEntity.ok(response);  // Map을 ResponseEntity로 감싸서 반환
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/commu/controller/ManageCommunityController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/ManageCommunityController.java
@@ -1,5 +1,7 @@
 package com.jandi.plan_backend.commu.controller;
 
+import com.jandi.plan_backend.commu.dto.CommentReportRespDTO;
+import com.jandi.plan_backend.commu.dto.CommentReportedListDTO;
 import com.jandi.plan_backend.commu.dto.CommunityListDTO;
 import com.jandi.plan_backend.commu.dto.CommunityReportedListDTO;
 import com.jandi.plan_backend.commu.service.ManageCommunityService;
@@ -45,6 +47,33 @@ public class ManageCommunityController {
                         "totalSize", reportedPosts.getTotalElements()
                 ),
                 "items", reportedPosts.getContent()
+        );
+
+        return ResponseEntity.ok(response);  // Map을 ResponseEntity로 감싸서 반환
+    }
+
+    // 신고 댓글 조회
+    @GetMapping("/reported/comments")
+    public ResponseEntity<Map<String, Object>> getReportedComments(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        if(userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "로그인이 필요합니다."));
+        }
+        String userEmail = userDetails.getUsername();
+
+        Page<CommentReportedListDTO> reportedComments = manageCommunityService.getReportedComments(userEmail, page, size);
+
+        Map<String, Object> response = Map.of(
+                "pageInfo", Map.of(
+                        "currentPage", reportedComments.getNumber(),
+                        "currentSize", reportedComments.getContent().size(),
+                        "totalPages", reportedComments.getTotalPages(),
+                        "totalSize", reportedComments.getTotalElements()
+                ),
+                "items", reportedComments.getContent()
         );
 
         return ResponseEntity.ok(response);  // Map을 ResponseEntity로 감싸서 반환

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommentReportedListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommentReportedListDTO.java
@@ -1,0 +1,15 @@
+package com.jandi.plan_backend.commu.dto;
+
+import com.jandi.plan_backend.commu.entity.Comment;
+import lombok.Getter;
+
+/** 관리자 페이지에서 신고된 댓글 목록을 조회할 때 응답을 위한 DTO */
+@Getter
+public class CommentReportedListDTO extends CommentRespDTO{
+    private final Integer reportCount;
+
+    public CommentReportedListDTO(Comment comment, Integer reportCount) {
+        super(comment);
+        this.reportCount = reportCount;
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommentRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommentRespDTO.java
@@ -1,6 +1,7 @@
 package com.jandi.plan_backend.commu.dto;
 
 import com.jandi.plan_backend.commu.entity.Comment;
+import com.jandi.plan_backend.image.service.ImageService;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -8,15 +9,26 @@ import java.time.LocalDateTime;
 @Data
 public class CommentRespDTO {
     private final Integer commentId;
-    private final Integer userId;
+    private final UserCommunityDTO user;
     private final LocalDateTime createdAt;
     private final String contents;
     private final Integer likeCount;
     private final Integer repliesCount; //답글 수
 
+    // 프로필 필요한 버전
+    public CommentRespDTO(Comment comment, ImageService imageService) {
+        this.commentId = comment.getCommentId();
+        this.user = new UserCommunityDTO(comment.getCommunity().getUser(), imageService);
+        this.createdAt = comment.getCreatedAt();
+        this.contents = comment.getContents();
+        this.likeCount = comment.getLikeCount();
+        this.repliesCount = comment.getRepliesCount();
+    }
+
+    // 프로필 필요 없는 버전
     public CommentRespDTO(Comment comment) {
         this.commentId = comment.getCommentId();
-        this.userId = comment.getUserId();
+        this.user = new UserCommunityDTO(comment.getCommunity().getUser());
         this.createdAt = comment.getCreatedAt();
         this.contents = comment.getContents();
         this.likeCount = comment.getLikeCount();

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -20,10 +20,22 @@ public class CommunityListDTO {
     private final Integer commentCount;
     private final Integer viewCount;
 
+    // 프로필 사진 필요한 버전
     public CommunityListDTO(Community community, ImageService imageService) {
         this.postId = community.getPostId();
         this.viewCount = community.getViewCount();
         this.user = new UserCommunityDTO(community.getUser(), imageService);
+        this.createdAt = community.getCreatedAt();
+        this.title = community.getTitle();
+        this.likeCount = community.getLikeCount();
+        this.commentCount = community.getCommentCount();
+    }
+
+    // 프로필 사진 필요없는 버전
+    public CommunityListDTO(Community community) {
+        this.postId = community.getPostId();
+        this.viewCount = community.getViewCount();
+        this.user = new UserCommunityDTO(community.getUser());
         this.createdAt = community.getCreatedAt();
         this.title = community.getTitle();
         this.likeCount = community.getLikeCount();

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReportedListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReportedListDTO.java
@@ -12,8 +12,8 @@ import lombok.Getter;
 public class CommunityReportedListDTO extends CommunityListDTO {
     private final Integer reportCount;
 
-    public CommunityReportedListDTO(Community community, ImageService imageService, Integer reportCount) {
-        super(community, imageService);
+    public CommunityReportedListDTO(Community community, Integer reportCount) {
+        super(community);
         this.reportCount = reportCount;
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReportedListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReportedListDTO.java
@@ -1,0 +1,19 @@
+package com.jandi.plan_backend.commu.dto;
+
+import com.jandi.plan_backend.commu.entity.Community;
+import com.jandi.plan_backend.image.service.ImageService;
+import lombok.Getter;
+
+/** 신고 게시물을 조회할 때 넘겨줄 dto.
+ * 기존 게시물 조회 dto에 신고 횟수를 함께 넘겨준다
+ */
+
+@Getter
+public class CommunityReportedListDTO extends CommunityListDTO {
+    private final Integer reportCount;
+
+    public CommunityReportedListDTO(Community community, ImageService imageService, Integer reportCount) {
+        super(community, imageService);
+        this.reportCount = reportCount;
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/commu/repository/CommentReportedRepository.java
+++ b/src/main/java/com/jandi/plan_backend/commu/repository/CommentReportedRepository.java
@@ -1,10 +1,21 @@
 package com.jandi.plan_backend.commu.repository;
 
 import com.jandi.plan_backend.commu.entity.CommentReported;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface CommentReportedRepository extends JpaRepository<CommentReported, Long> {
     Optional<CommentReported> findByUser_userIdAndComment_CommentId(Integer userId, Integer commentId);
+
+    // 신고된 이력이 있는 댓글을 중복없게 commentId 별로 그룹화해서 신고 횟수를 계산한 뒤,
+    // 신고 횟수로 1차 정렬 후 동일 신고 횟수라면 commentId 역순 정렬해서 반환
+    @Query("""
+    SELECT comment.comment, COUNT(comment) FROM CommentReported comment GROUP BY comment.comment
+    ORDER BY COUNT(comment) DESC, comment.comment.commentId DESC
+    """)
+    Page<Object[]> findReportedCommentsWithCount(Pageable pageable);
 }

--- a/src/main/java/com/jandi/plan_backend/commu/repository/CommunityReportedRepository.java
+++ b/src/main/java/com/jandi/plan_backend/commu/repository/CommunityReportedRepository.java
@@ -1,10 +1,23 @@
 package com.jandi.plan_backend.commu.repository;
 
+import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.commu.entity.CommunityReported;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommunityReportedRepository extends JpaRepository<CommunityReported, Long> {
     Optional<CommunityReported> findByUser_userIdAndCommunity_postId(Integer userId, Integer postId);
+
+    // 신고된 이력이 있는 게시글을 중복없게 postId 별로 그룹화해서 신고 횟수를 계산한 뒤,
+    // 신고 횟수로 1차 정렬 후 동일 신고 횟수라면 postId 역순 정렬해서 반환
+    @Query("""
+    SELECT cr.community, COUNT(cr) FROM CommunityReported cr GROUP BY cr.community
+    ORDER BY COUNT(cr) DESC, cr.community.postId DESC
+    """)
+    Page<Object[]> findReportedCommunitiesWithCount(Pageable pageable);
 }

--- a/src/main/java/com/jandi/plan_backend/commu/repository/CommunityReportedRepository.java
+++ b/src/main/java/com/jandi/plan_backend/commu/repository/CommunityReportedRepository.java
@@ -16,8 +16,8 @@ public interface CommunityReportedRepository extends JpaRepository<CommunityRepo
     // 신고된 이력이 있는 게시글을 중복없게 postId 별로 그룹화해서 신고 횟수를 계산한 뒤,
     // 신고 횟수로 1차 정렬 후 동일 신고 횟수라면 postId 역순 정렬해서 반환
     @Query("""
-    SELECT cr.community, COUNT(cr) FROM CommunityReported cr GROUP BY cr.community
-    ORDER BY COUNT(cr) DESC, cr.community.postId DESC
+    SELECT post.community, COUNT(post) FROM CommunityReported post GROUP BY post.community
+    ORDER BY COUNT(post) DESC, post.community.postId DESC
     """)
     Page<Object[]> findReportedCommunitiesWithCount(Pageable pageable);
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/CommentService.java
@@ -122,7 +122,7 @@ public class CommentService {
         post.setCommentCount(post.getCommentCount() + 1); // 게시글의 댓글 수 증가
         communityRepository.save(post);
 
-        return new CommentRespDTO(comment);
+        return new CommentRespDTO(comment, imageService);
     }
 
     /** 댓글 수정 */
@@ -140,7 +140,7 @@ public class CommentService {
 
         // DB 저장 및 반환
         commentRepository.save(comment);
-        return new CommentRespDTO(comment);
+        return new CommentRespDTO(comment, imageService);
     }
 
     /**

--- a/src/main/java/com/jandi/plan_backend/commu/service/ManageCommunityService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/ManageCommunityService.java
@@ -1,7 +1,52 @@
 package com.jandi.plan_backend.commu.service;
 
+import com.jandi.plan_backend.commu.dto.CommunityListDTO;
+import com.jandi.plan_backend.commu.dto.CommunityReportedListDTO;
+import com.jandi.plan_backend.commu.entity.Community;
+import com.jandi.plan_backend.commu.entity.CommunityReported;
+import com.jandi.plan_backend.commu.repository.CommunityReportedRepository;
+import com.jandi.plan_backend.image.service.ImageService;
+import com.jandi.plan_backend.user.entity.User;
+import com.jandi.plan_backend.util.ValidationUtil;
+import com.jandi.plan_backend.util.service.PaginationService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class ManageCommunityService {
+    private final ValidationUtil validationUtil;
+    private final CommunityReportedRepository communityReportedRepository;
+    private final ImageService imageService;
+
+    public ManageCommunityService(
+            ValidationUtil validationUtil,
+            CommunityReportedRepository communityReportedRepository,
+            ImageService imageService
+    ) {
+        this.validationUtil = validationUtil;
+        this.communityReportedRepository = communityReportedRepository;
+        this.imageService = imageService;
+    }
+
+    public Page<CommunityReportedListDTO> getReportedPosts(String userEmail, int page, int size) {
+        //유저 검증
+        User admin = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserIsAdmin(admin);
+
+        long totalCount = communityReportedRepository.count(); // 전체 신고된 게시글 수
+        return PaginationService.getPagedData(page, size, totalCount,
+                communityReportedRepository::findReportedCommunitiesWithCount,  // 데이터 조회
+                ReportedObj -> {
+                    Community community = (Community) ReportedObj[0];  // 신고된 게시글
+                    Integer reportCount = ((Number) ReportedObj[1]).intValue();  // 신고 횟수
+                    return new CommunityReportedListDTO(community, imageService, reportCount);
+                }
+        );
+    }
+
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/ManageCommunityService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/ManageCommunityService.java
@@ -1,18 +1,16 @@
 package com.jandi.plan_backend.commu.service;
 
-import com.jandi.plan_backend.commu.dto.CommunityListDTO;
+import com.jandi.plan_backend.commu.dto.CommentReportedListDTO;
 import com.jandi.plan_backend.commu.dto.CommunityReportedListDTO;
+import com.jandi.plan_backend.commu.entity.Comment;
 import com.jandi.plan_backend.commu.entity.Community;
-import com.jandi.plan_backend.commu.entity.CommunityReported;
+import com.jandi.plan_backend.commu.repository.CommentReportedRepository;
 import com.jandi.plan_backend.commu.repository.CommunityReportedRepository;
 import com.jandi.plan_backend.image.service.ImageService;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.util.ValidationUtil;
 import com.jandi.plan_backend.util.service.PaginationService;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,16 +19,15 @@ import java.util.List;
 public class ManageCommunityService {
     private final ValidationUtil validationUtil;
     private final CommunityReportedRepository communityReportedRepository;
-    private final ImageService imageService;
+    private final CommentReportedRepository commentReportedRepository;
 
     public ManageCommunityService(
             ValidationUtil validationUtil,
             CommunityReportedRepository communityReportedRepository,
-            ImageService imageService
-    ) {
+            CommentReportedRepository commentReportedRepository) {
         this.validationUtil = validationUtil;
         this.communityReportedRepository = communityReportedRepository;
-        this.imageService = imageService;
+        this.commentReportedRepository = commentReportedRepository;
     }
 
     public Page<CommunityReportedListDTO> getReportedPosts(String userEmail, int page, int size) {
@@ -44,9 +41,25 @@ public class ManageCommunityService {
                 ReportedObj -> {
                     Community community = (Community) ReportedObj[0];  // 신고된 게시글
                     Integer reportCount = ((Number) ReportedObj[1]).intValue();  // 신고 횟수
-                    return new CommunityReportedListDTO(community, imageService, reportCount);
+                    return new CommunityReportedListDTO(community, reportCount);
                 }
         );
     }
 
+    // 신고 댓글 조회
+    public Page<CommentReportedListDTO> getReportedComments(String userEmail, int page, int size) {
+        //유저 검증
+        User admin = validationUtil.validateUserExists(userEmail);
+        validationUtil.validateUserIsAdmin(admin);
+
+        long totalCount = commentReportedRepository.count(); // 전체 신고된 게시글 수
+        return PaginationService.getPagedData(page, size, totalCount,
+                commentReportedRepository::findReportedCommentsWithCount,  // 데이터 조회
+                ReportedObj -> {
+                    Comment comment = (Comment) ReportedObj[0];  // 신고된 댓글
+                    Integer reportCount = ((Number) ReportedObj[1]).intValue();  // 신고 횟수
+                    return new CommentReportedListDTO(comment, reportCount);
+                }
+        );
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
+++ b/src/main/java/com/jandi/plan_backend/trip/controller/TripController.java
@@ -26,9 +26,12 @@ public class TripController {
     @GetMapping("/allTrips")
     public Map<String, Object> getAllTrips(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestHeader(value = "Authorization", required = false) String token
     ){
-        Page<TripRespDTO> tripsPage = tripService.getAllTrips(page, size);
+        String userEmail = (token == null) ?
+                null : jwtTokenProvider.getEmail(token.replace("Bearer ", ""));
+        Page<TripRespDTO> tripsPage = tripService.getAllTrips(userEmail, page, size);
 
         return Map.of(
                 "pageInfo", Map.of(

--- a/src/main/java/com/jandi/plan_backend/trip/dto/MyTripRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/trip/dto/MyTripRespDTO.java
@@ -30,4 +30,9 @@ public class MyTripRespDTO extends TripRespDTO {
         super(user, userProfileUrl, trip, cityImageUrl, tripImageUrl);
         this.privatePlan = trip.getPrivatePlan();
     }
+
+    public MyTripRespDTO(TripRespDTO tripRespDTO, boolean privatePlan) {
+        super(tripRespDTO);
+        this.privatePlan = privatePlan;
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/trip/dto/TripItemRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/trip/dto/TripItemRespDTO.java
@@ -37,4 +37,10 @@ public class TripItemRespDTO extends TripRespDTO {
         this.privatePlan = trip.getPrivatePlan();
         this.liked = liked;
     }
+
+    public TripItemRespDTO(TripRespDTO tripRespDTO, Boolean liked) {
+        super(tripRespDTO);
+        this.privatePlan = tripRespDTO.getPrivatePlan();
+        this.liked = liked;
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/trip/dto/TripRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/trip/dto/TripRespDTO.java
@@ -69,4 +69,24 @@ public class TripRespDTO {
         this.cityImageUrl = cityImageUrl;
         this.tripImageUrl = tripImageUrl;
     }
+
+    public TripRespDTO(TripRespDTO tripRespDTO) {
+        this.user = tripRespDTO.getUser();
+        this.tripId = tripRespDTO.getTripId();
+        this.title = tripRespDTO.getTitle();
+        this.startDate = tripRespDTO.getStartDate();
+        this.endDate = tripRespDTO.getEndDate();
+        this.likeCount = tripRespDTO.getLikeCount();
+        this.budget = tripRespDTO.getBudget();
+        this.cityId = tripRespDTO.getCityId();
+        this.cityName = tripRespDTO.getCityName();
+        this.countryName = tripRespDTO.getCountryName();
+        this.privatePlan = tripRespDTO.getPrivatePlan();
+
+        this.latitude = tripRespDTO.getLatitude();
+        this.longitude = tripRespDTO.getLongitude();
+        this.cityImageUrl = tripRespDTO.getCityImageUrl();
+
+        this.tripImageUrl = tripRespDTO.getTripImageUrl();
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/trip/repository/TripRepository.java
+++ b/src/main/java/com/jandi/plan_backend/trip/repository/TripRepository.java
@@ -27,4 +27,7 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
     List<Trip> findTop10ByPrivatePlanFalseOrderByLikeCountDesc();
 
     boolean existsByCity(City city);
+
+    // 타인의 공개 플랜 + 본인의 모든 플랜 조회
+    Page<Trip> findByPrivatePlanOrUser(boolean b, User user, Pageable pageable);
 }

--- a/src/main/java/com/jandi/plan_backend/user/controller/ManageUserController.java
+++ b/src/main/java/com/jandi/plan_backend/user/controller/ManageUserController.java
@@ -47,7 +47,7 @@ public class ManageUserController {
     }
 
     /** 부적절 유저 목록 조회 */
-    @GetMapping("/restricted")
+    @GetMapping("/reported")
     public Map<String, Object> getRestrictedUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -86,10 +86,16 @@ public class ValidationUtil {
         }
     }
 
+    // 검증용
     public void validateUserIsAdmin(User user) {
         if (user.getUserId() != 1) {
             throw new BadRequestExceptionMessage("관리자 권한이 필요한 작업입니다.");
         }
+    }
+
+    // 판별용
+    public Boolean validateUserIsAdmin(Integer userId) {
+        return userId.equals(1);
     }
 
     /* ==========================


### PR DESCRIPTION
## 작업 내용
- 신고 게시글 조회 기능 추가
- 신고 댓글 조회 기능 추가
- 로그인 상황에 따라 여행 계획 정보를 달리 주도록 수정

## 전달 사항
- CommentRespDTO에서 userId 대신 UserCommunityDTO 객체를 넘겨주는 것으로 변경
- CommentRespDTO 생성자를 프로필 필요/불필요 버전 두개로 구분
- 제한된 사용자 목록 조회 API의 엔드포인트 수정: `/api/manage/user/restricted` -> `~/reported`
- tripService에서 image를 붙이느라 중복되는 코드들을 convertToTripRespDTO() 메서드로 별도 분리하고, if/else문을 switch문으로 바꾸는 등 약간의(?) 코드 가독성 최적화를 함