### PR TITLE
Feat: 권한 수정 API 추가

### DIFF
--- a/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
+++ b/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
@@ -164,7 +164,10 @@ public class SecurityConfig {
                                 // reported - delete 관련
                                 "/api/manage/user/delete/{userId}",
                                 "/api/manage/community/delete/posts/{postId}",
-                                "/api/manage/community/delete/comments/{commentId}"
+                                "/api/manage/community/delete/comments/{commentId}",
+
+                                // 유저 관련
+                                "api/manage/user/change-role/{user_id}"
                         ).hasRole("ADMIN")
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/jandi/plan_backend/user/controller/ManageUserController.java
+++ b/src/main/java/com/jandi/plan_backend/user/controller/ManageUserController.java
@@ -2,10 +2,12 @@ package com.jandi.plan_backend.user.controller;
 
 import com.jandi.plan_backend.commu.dto.UserListDTO;
 import com.jandi.plan_backend.security.JwtTokenProvider;
+import com.jandi.plan_backend.user.dto.RoleReqDTO;
 import com.jandi.plan_backend.user.service.ManageUserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -102,5 +104,20 @@ public class ManageUserController {
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
+    }
+
+    /** 권한 변경 */
+    @PutMapping("/change-role/{userId}")
+    public ResponseEntity<?> changeUserRole(
+            @PathVariable Integer userId,
+            @RequestBody RoleReqDTO reqDTO,
+            @RequestHeader("Authorization") String token // 헤더의 Authorization에서 JWT 토큰 받기
+    ) {
+        // Jwt 토큰으로부터 유저 이메일 추출
+        String jwtToken = token.replace("Bearer ", "");
+        String userEmail = jwtTokenProvider.getEmail(jwtToken);
+
+        manageUserService.changeUserRole(userId, reqDTO, userEmail);
+        return ResponseEntity.ok().body("성공적으로 변경되었습니다.");
     }
 }

--- a/src/main/java/com/jandi/plan_backend/user/dto/RoleReqDTO.java
+++ b/src/main/java/com/jandi/plan_backend/user/dto/RoleReqDTO.java
@@ -1,0 +1,8 @@
+package com.jandi.plan_backend.user.dto;
+
+import lombok.Data;
+
+@Data
+public class RoleReqDTO {
+    String roleName;
+}

--- a/src/main/java/com/jandi/plan_backend/user/entity/Role.java
+++ b/src/main/java/com/jandi/plan_backend/user/entity/Role.java
@@ -22,5 +22,14 @@ public enum Role {
         }
         throw new IllegalArgumentException("잘못된 role 입력: " + value);
     }
+
+    public static int fromString(String roleName) {
+        for (Role role : Role.values()) {
+            if (role.name().equalsIgnoreCase(roleName)) { // 문자열을 int로 변환
+                return role.getValue();
+            }
+        }
+        throw new IllegalArgumentException("잘못된 role 입력: " + roleName);
+    }
 }
 

--- a/src/main/java/com/jandi/plan_backend/user/entity/RoleLog.java
+++ b/src/main/java/com/jandi/plan_backend/user/entity/RoleLog.java
@@ -1,0 +1,35 @@
+package com.jandi.plan_backend.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+/**
+ * role 변경을 추적 기록하는 엔티티
+ */
+
+@Entity
+@Table(name = "role_log")
+@Data
+public class RoleLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_user_id", nullable = false) // 변경된 사용자의 ID
+    private User user;
+
+    @Column(nullable = false)
+    private int prevRole; // 변경 전 역할
+
+    @Column(nullable = false)
+    private int newRole; // 변경 후 역할
+
+    @Column(nullable = false)
+    private LocalDateTime changedAt; // 변경 시각
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "changed_by_user_id", nullable = false) // 변경 요청자의 ID
+    private User changedBy;
+}

--- a/src/main/java/com/jandi/plan_backend/user/entity/RoleLog.java
+++ b/src/main/java/com/jandi/plan_backend/user/entity/RoleLog.java
@@ -29,7 +29,6 @@ public class RoleLog {
     @Column(nullable = false)
     private LocalDateTime changedAt; // 변경 시각
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "changed_by_user_id", nullable = false) // 변경 요청자의 ID
-    private User changedBy;
+    @Column(nullable = false)
+    private String changedBy; // 변경 요청자의 이메일 주소 or 시스템
 }

--- a/src/main/java/com/jandi/plan_backend/user/entity/User.java
+++ b/src/main/java/com/jandi/plan_backend/user/entity/User.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@EntityListeners(UserEntityListener.class) // role 변경 감지용
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "userId")
 @Entity
 @Table(name = "users")

--- a/src/main/java/com/jandi/plan_backend/user/entity/UserEntityListener.java
+++ b/src/main/java/com/jandi/plan_backend/user/entity/UserEntityListener.java
@@ -1,0 +1,44 @@
+package com.jandi.plan_backend.user.entity;
+
+import com.jandi.plan_backend.user.repository.RoleLogRepository;
+import jakarta.persistence.PostUpdate;
+import jakarta.persistence.PreUpdate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class UserEntityListener {
+
+    private static RoleLogRepository roleLogRepository;
+
+    @Autowired
+    public void setRoleLogRepository(RoleLogRepository roleLogRepository) {
+        UserEntityListener.roleLogRepository = roleLogRepository;
+    }
+
+    private int previousRole;
+
+    @PreUpdate
+    public void beforeUpdate(User user) {
+        // 업데이트 이전의 역할 저장
+        this.previousRole = user.getRole();
+    }
+
+    @PostUpdate
+    public void afterUpdate(User user) {
+        // 만약 Role이 변경되었다면 로그 저장
+        if (this.previousRole != user.getRole()) {
+            RoleLog roleLog = new RoleLog();
+            roleLog.setUser(user);
+            roleLog.setPrevRole(this.previousRole);
+            roleLog.setNewRole(user.getRole());
+            roleLog.setChangedBy("SYSTEM"); // 비정상적인 변경은 SYSTEM이 감지함
+
+            roleLog.setChangedAt(LocalDateTime.now());
+            roleLogRepository.save(roleLog);
+        }
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/user/entity/UserEntityListener.java
+++ b/src/main/java/com/jandi/plan_backend/user/entity/UserEntityListener.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Component
 @RequiredArgsConstructor
@@ -31,13 +32,13 @@ public class UserEntityListener {
     public void afterUpdate(User user) {
         // 만약 Role이 변경되었다면 로그 저장
         if (this.previousRole != user.getRole()) {
+            // 로그 기록
             RoleLog roleLog = new RoleLog();
             roleLog.setUser(user);
             roleLog.setPrevRole(this.previousRole);
             roleLog.setNewRole(user.getRole());
             roleLog.setChangedBy("SYSTEM"); // 비정상적인 변경은 SYSTEM이 감지함
-
-            roleLog.setChangedAt(LocalDateTime.now());
+            roleLog.setChangedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
             roleLogRepository.save(roleLog);
         }
     }

--- a/src/main/java/com/jandi/plan_backend/user/repository/RoleLogRepository.java
+++ b/src/main/java/com/jandi/plan_backend/user/repository/RoleLogRepository.java
@@ -1,0 +1,7 @@
+package com.jandi.plan_backend.user.repository;
+
+import com.jandi.plan_backend.user.entity.RoleLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleLogRepository extends JpaRepository<RoleLog, Long> {
+}

--- a/src/main/java/com/jandi/plan_backend/user/service/ManageUserService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/ManageUserService.java
@@ -113,7 +113,7 @@ public class ManageUserService {
             roleLog.setUser(targetUser);
             roleLog.setPrevRole(previousRole);
             roleLog.setNewRole(updatedRole);
-            roleLog.setChangedBy(curUser);
+            roleLog.setChangedBy(curUser.getEmail());
             roleLog.setChangedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
             roleLogRepository.save(roleLog);
         }catch(Exception e){

--- a/src/main/java/com/jandi/plan_backend/user/service/ManageUserService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/ManageUserService.java
@@ -99,20 +99,23 @@ public class ManageUserService {
             User curUser = validationUtil.validateUserExists(curUserEmail);
 
             // 기존 역할 저장
-            int previousRole = targetUser.getRole();
+            int previousRole = targetUser.getRole(); // 기존 역할
+            int intRole = Role.fromString(reqDTO.getRoleName()); // 새 역할: 문자열 -> 숫자로 변환
 
-            // 문자열(Role) → 숫자(int) 변환
-            int updatedRole = Role.fromString(reqDTO.getRoleName());
+            // 기존과 같을 경우 변경하지 않고 에러 반환
+            if(previousRole==intRole) {
+                throw new BadRequestExceptionMessage("기존과 동일한 권한을 입력했습니다.");
+            }
 
             // 역할 변경
-            targetUser.setRole(updatedRole);
+            targetUser.setRole(intRole);
             userRepository.save(targetUser);
 
             // 로그 기록
             RoleLog roleLog = new RoleLog();
             roleLog.setUser(targetUser);
             roleLog.setPrevRole(previousRole);
-            roleLog.setNewRole(updatedRole);
+            roleLog.setNewRole(intRole);
             roleLog.setChangedBy(curUser.getEmail());
             roleLog.setChangedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
             roleLogRepository.save(roleLog);

--- a/src/main/java/com/jandi/plan_backend/user/service/RoleMonitorService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/RoleMonitorService.java
@@ -1,0 +1,43 @@
+package com.jandi.plan_backend.user.service;
+
+import com.jandi.plan_backend.user.entity.RoleLog;
+import com.jandi.plan_backend.user.repository.RoleLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoleMonitorService {
+
+    private final RoleLogRepository roleLogRepository;
+
+    /**
+     * 1시간마다 Role 변경 로그를 감시하고, 비정상적인 변경이 있는 경우 경고 로그를 출력합니다.
+     */
+    @Scheduled(fixedRate = 3600000) // 1시간마다 실행
+    public void monitorRoleChanges() {
+        log.info("Role 변경 로그 감시 시작...");
+
+        List<RoleLog> suspiciousLogs = roleLogRepository.findAll().stream()
+                .filter(log -> "SYSTEM".equals(log.getChangedBy()))
+                .toList();
+
+        if (!suspiciousLogs.isEmpty()) {
+            log.warn("비정상적인 Role 변경 감지");
+            for (RoleLog logEntry : suspiciousLogs) {
+                log.warn("[UserID: {}] role {} → {} 으로 변경됨",
+                        logEntry.getUser().getUserId(),
+                        logEntry.getPrevRole(),
+                        logEntry.getNewRole());
+            }
+        } else {
+            log.info("비정상적인 Role 변경 없음");
+        }
+    }
+}
+


### PR DESCRIPTION
## 작업 내용
- 관리자의 경우에만 특정 유저의 권한을 수정할 수 있도록 api 추가
- 권한 변경 API를 사용할 때마다 로깅되도록 했음

## 전달 사항
- role_log 테이블 신규 생성
- api로 정상적으로 변경할 때(하이버네이트 이용)는 로깅이 되는데, db를 직접 수정하는 등 비정상적인 권한 변경은 mysql 자체에서 이루어지는 거라 로그가 추가되질 않아서 논의가 필요할 것 같습니다