### PR TITLE
Chore: 일부 dto에서 유저의 role도 반환하도록 수정

### DIFF
--- a/src/main/java/com/jandi/plan_backend/user/controller/ManageUserController.java
+++ b/src/main/java/com/jandi/plan_backend/user/controller/ManageUserController.java
@@ -1,6 +1,6 @@
 package com.jandi.plan_backend.user.controller;
 
-import com.jandi.plan_backend.commu.dto.UserListDTO;
+import com.jandi.plan_backend.user.dto.UserListDTO;
 import com.jandi.plan_backend.security.JwtTokenProvider;
 import com.jandi.plan_backend.user.service.ManageUserService;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/jandi/plan_backend/user/dto/UserInfoRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/user/dto/UserInfoRespDTO.java
@@ -15,4 +15,5 @@ public class UserInfoRespDTO {
     private boolean verified;
     private boolean reported;
     private String profileImageUrl;
+    private String role;
 }

--- a/src/main/java/com/jandi/plan_backend/user/dto/UserListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/user/dto/UserListDTO.java
@@ -1,4 +1,4 @@
-package com.jandi.plan_backend.commu.dto;
+package com.jandi.plan_backend.user.dto;
 
 import com.jandi.plan_backend.user.entity.User;
 import lombok.Getter;
@@ -15,6 +15,7 @@ public class UserListDTO {
     private LocalDateTime createdAt;
     private Boolean reported;
     private Boolean verified;
+    private String role;
 
     public UserListDTO(User user) {
         this.userId = user.getUserId();
@@ -25,5 +26,6 @@ public class UserListDTO {
         this.createdAt = user.getCreatedAt();
         this.reported = user.getReported();
         this.verified = user.getVerified();
+        this.role = user.getRoleEnum().name();
     }
 }

--- a/src/main/java/com/jandi/plan_backend/user/service/ManageUserService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/ManageUserService.java
@@ -1,6 +1,6 @@
 package com.jandi.plan_backend.user.service;
 
-import com.jandi.plan_backend.commu.dto.UserListDTO;
+import com.jandi.plan_backend.user.dto.UserListDTO;
 import com.jandi.plan_backend.user.entity.User;
 import com.jandi.plan_backend.user.repository.UserRepository;
 import com.jandi.plan_backend.util.ValidationUtil;
@@ -9,8 +9,6 @@ import com.jandi.plan_backend.util.service.PaginationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
-
-import java.util.Arrays;
 
 @Slf4j
 @Service

--- a/src/main/java/com/jandi/plan_backend/user/service/UserService.java
+++ b/src/main/java/com/jandi/plan_backend/user/service/UserService.java
@@ -223,6 +223,7 @@ public class UserService {
         dto.setUsername(user.getUserName());
         dto.setVerified(user.getVerified());
         dto.setReported(user.getReported());
+        dto.setRole(user.getRoleEnum().name());
 
         // 3. 사용자 프로필 이미지 조회
         //    targetType이 "profile"이고, targetId가 userId인 Image를 조회


### PR DESCRIPTION
/api/users/profile, /api/manage/user/reported, /api/manage/user/all에서 응답을 줄 때 role을 보내줄 수 있도록 관련된 dto 수정
* /api/manage/user/reported, /api/manage/user/all -> UserListDTO.java에 role 추가
* /api/users/profile -> UserInfoRespDTO.java에 role 추가