### PR TITLE
Fix: 오류 메시지 수정 

### DIFF
--- a/src/main/java/com/jandi/plan_backend/global/CustomErrorController.java
+++ b/src/main/java/com/jandi/plan_backend/global/CustomErrorController.java
@@ -26,13 +26,22 @@ public class CustomErrorController implements ErrorController {
     public ResponseEntity<?> handleError(WebRequest webRequest) {
         Map<String, Object> attributes = errorAttributes.getErrorAttributes(webRequest, ErrorAttributeOptions.defaults());
         int status = (int) attributes.getOrDefault("status", 500);
-        String message = (String) attributes.getOrDefault("error", "Internal Server Error");
+
+        String message;
+        if (status == 401) {
+            message = "토큰값 확인이 필요합니다.";
+        } else if (status == 404) {
+            message = "요청하신 경로를 찾을 수 없습니다.";
+        } else {
+            message = (String) attributes.getOrDefault("message",
+                    attributes.getOrDefault("error", "알 수 없는 오류 발생"));
+        }
 
         // 원하는 추가 정보를 설정할 수 있습니다.
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("status", status);
-        errorResponse.put("error", message);
-        errorResponse.put("message", attributes.getOrDefault("message", "요청하신 경로를 찾을 수 없습니다."));
+        errorResponse.put("error", errorAttributes.getErrorAttributes(webRequest, ErrorAttributeOptions.defaults()).get("error"));
+        errorResponse.put("message", message);
         errorResponse.put("timestamp", LocalDateTime.now());
 
         return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(status));

--- a/src/main/java/com/jandi/plan_backend/security/JwtTokenProvider.java
+++ b/src/main/java/com/jandi/plan_backend/security/JwtTokenProvider.java
@@ -137,9 +137,18 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token);
             log.debug("JWT 토큰 유효함");
             return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            log.error("JWT 토큰 유효성 검사 실패: {}", e.getMessage());
-            return false;
+        } catch (ExpiredJwtException e) {
+            log.error("JWT 토큰 유효성 검사 실패: 토큰 만료");
+        } catch (SecurityException e) {
+            log.error("JWT 토큰 유효성 검사 실패: 유효하지 않은 서명");
+        } catch (MalformedJwtException e) {
+            log.error("JWT 토큰 유효성 검사 실패: 잘못된 형식의 토큰");
+        } catch (UnsupportedJwtException e) {
+            log.error("JWT 토큰 유효성 검사 실패: 지원되지 않는 토큰");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰 유효성 검사 실패: 빈 토큰 또는 잘못된 토큰");
         }
+        return false;
     }
+
 }


### PR DESCRIPTION
## 작업 내용
- 진짜 오류 메시지가  "요청하신 경로를 찾을 수 없습니다"에 가려져 보이지 않던 현상 수정
- 만료된 토큰을 보낸 상황에서 401 "요청하신 경로를 찾을 수 없습니다"라는 오류를 응답하는 현상 수정
- 인증 관련 로직이 404 not found보다 우선되도록 하고, 아래 표와 같이 404는 로그인한 상태에서 페이지가 없을 때만 나오도록 수정

|                         | 존재하지 않는 페이지          | 권한 필요없는 페이지<br>(미로그인도 접근 가능) | 권한 필요한 페이지<br>(로그인 필요, 특정 권한부터 접근 가능) |
|-------------------------|--------------------------|----------------------------------|----------------------------------|
| **토큰값 미존재**       | 401 로그인이 필요합니다  | 200 OK                          | 401 로그인이 필요합니다         |
| **잘못된 토큰값 존재**   | 401 토큰값 확인이 필요합니다 | 401 토큰값 확인이 필요합니다    | 401 토큰값 확인이 필요합니다    |
| **유효한 토큰값 존재 (권한 부족)** | 404 요청하신 경로를 찾을 수 없습니다 | -                                | 403 해당 권한이 없습니다        |
| **유효한 토큰값 존재 (권한 만족)** | 404 요청하신 경로를 찾을 수 없습니다 | 200 OK                          | 200 OK                          |

