### PR TITLE
Feat: 여행 계획 조회 관련 권한 수정

### DIFF
--- a/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
+++ b/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
@@ -148,11 +148,8 @@ public class SecurityConfig {
                                 "/api/manage/community/reported/comments", "/api/manage/community/reported/posts",
 
                                 // 통계 조회
-                                "/api/manage/util/all", "/api/manage/util/month/users"
-                        ).hasAnyRole("STAFF", "ADMIN")
+                                "/api/manage/util/all", "/api/manage/util/month/users",
 
-                        // 관리자 권한 필요
-                        .requestMatchers(
                                 // resource - notice & banner 관련
                                 "/api/notice/", "/api/notice/{noticeId}",
                                 "/api/banner/lists", "/api/banner/lists/{bannderId}", "/api/images/upload/notice",
@@ -165,8 +162,11 @@ public class SecurityConfig {
                                 // reported - delete 관련
                                 "/api/manage/user/delete/{userId}",
                                 "/api/manage/community/delete/posts/{postId}",
-                                "/api/manage/community/delete/comments/{commentId}",
+                                "/api/manage/community/delete/comments/{commentId}"
+                        ).hasAnyRole("STAFF", "ADMIN")
 
+                        // 관리자 권한 필요
+                        .requestMatchers(
                                 // 유저 관련
                                 "api/manage/user/change-role/{user_id}"
                         ).hasRole("ADMIN")

--- a/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
+++ b/src/main/java/com/jandi/plan_backend/config/SecurityConfig.java
@@ -160,7 +160,6 @@ public class SecurityConfig {
                                 "/api/manage/trip/cities", "/api/manage/trip/cities/{cityId}",
 
                                 // reported - delete 관련
-                                "/api/manage/user/delete/{userId}",
                                 "/api/manage/community/delete/posts/{postId}",
                                 "/api/manage/community/delete/comments/{commentId}"
                         ).hasAnyRole("STAFF", "ADMIN")
@@ -168,6 +167,7 @@ public class SecurityConfig {
                         // 관리자 권한 필요
                         .requestMatchers(
                                 // 유저 관련
+                                "/api/manage/user/delete/{userId}",
                                 "api/manage/user/change-role/{user_id}"
                         ).hasRole("ADMIN")
                         // 그 외 모든 요청은 인증 필요

--- a/src/main/java/com/jandi/plan_backend/trip/repository/TripParticipantRepository.java
+++ b/src/main/java/com/jandi/plan_backend/trip/repository/TripParticipantRepository.java
@@ -5,6 +5,7 @@ import com.jandi.plan_backend.trip.entity.TripParticipantId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 여행 계획 동반자 관련 레포지토리
@@ -14,4 +15,7 @@ public interface TripParticipantRepository extends JpaRepository<TripParticipant
     List<TripParticipant> findByTrip_TripId(Integer tripId);
 
     void deleteByTrip_TripIdAndParticipant_UserName(Integer tripId, String userName);
+
+    //해당 여행계획의 동반자인지 여부를 반환
+    Optional<TripParticipant> findByTrip_TripIdAndParticipant_UserId(Integer tripId, Integer userId);
 }

--- a/src/main/java/com/jandi/plan_backend/trip/repository/TripRepository.java
+++ b/src/main/java/com/jandi/plan_backend/trip/repository/TripRepository.java
@@ -36,4 +36,15 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
     List<Trip> searchByCityNameContainingIgnoreCase(String keyword);
 
     List<Trip> findByUser(User user);
+
+    // 공개 플랜이거나 본인의 플랜이거나 동반자로 등록된 플랜의 갯수 반환
+    @Query("SELECT COUNT(t) FROM Trip t WHERE t.privatePlan = false OR t.user = :user OR t.tripId IN " +
+            "(SELECT tp.trip.tripId FROM TripParticipant tp WHERE tp.participant = :user)")
+    long countVisibleTrips(User user);
+
+    // 공개 플랜이거나 본인의 플랜이거나 동반자로 등록된 플랜 목록 반환
+    @Query("SELECT t FROM Trip t WHERE t.privatePlan = false OR t.user = :user OR t.tripId IN " +
+            "(SELECT tp.trip.tripId FROM TripParticipant tp WHERE tp.participant = :user)")
+    Page<Trip> findVisibleTrips(User user, Pageable pageable);
+
 }

--- a/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
+++ b/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
@@ -133,14 +133,16 @@ public class TripService {
                 );
             } else {
                 // 일반 -> 타인 공개 + 본인 전체
-                long totalCount = tripRepository.countByPrivatePlan(false) + tripRepository.countByUser(user);
+                long totalCount = tripRepository.countVisibleTrips(user);
+
                 return PaginationService.getPagedData(page, size, totalCount,
-                        pageable -> tripRepository.findByPrivatePlanOrUser(
-                                false, user,
+                        pageable -> tripRepository.findVisibleTrips(
+                                user,
                                 PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort)
                         ),
                         this::convertToTripRespDTO
                 );
+
             }
         }
     }

--- a/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
+++ b/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
@@ -120,8 +120,10 @@ public class TripService {
             );
         } else {
             User user = validationUtil.validateUserExists(userEmail);
-            if (validationUtil.validateUserIsAdmin(user)) {
-                // 관리자 -> 전체
+            boolean isAdmin = validationUtil.validateUserIsAdmin(user);
+            boolean isStaff = validationUtil.validateUserIsStaff(user);
+            if (isAdmin || isStaff) {
+                // 관리자 or 스텝 -> 전체
                 long totalCount = tripRepository.count();
                 return PaginationService.getPagedData(page, size, totalCount,
                         pageable -> tripRepository.findAll(

--- a/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
+++ b/src/main/java/com/jandi/plan_backend/trip/service/TripService.java
@@ -6,7 +6,9 @@ import com.jandi.plan_backend.itinerary.repository.ReservationRepository;
 import com.jandi.plan_backend.trip.dto.*;
 import com.jandi.plan_backend.trip.entity.Trip;
 import com.jandi.plan_backend.trip.entity.TripLike;
+import com.jandi.plan_backend.trip.entity.TripParticipant;
 import com.jandi.plan_backend.trip.repository.TripLikeRepository;
+import com.jandi.plan_backend.trip.repository.TripParticipantRepository;
 import com.jandi.plan_backend.trip.repository.TripRepository;
 import com.jandi.plan_backend.user.entity.City;
 import com.jandi.plan_backend.user.entity.User;
@@ -39,6 +41,7 @@ public class TripService {
     private final CityRepository cityRepository;
     private final ItineraryRepository itineraryRepository;
     private final ReservationRepository reservationRepository;
+    private final TripParticipantRepository tripParticipantRepository;
 
     private final String urlPrefix = "https://storage.googleapis.com/plan-storage/";
     private final Sort sortByCreate = Sort.by(Sort.Direction.DESC, "createdAt");
@@ -49,7 +52,8 @@ public class TripService {
                        ImageService imageService,
                        CityRepository cityRepository,
                        ItineraryRepository itineraryRepository,
-                       ReservationRepository reservationRepository) {
+                       ReservationRepository reservationRepository,
+                       TripParticipantRepository tripParticipantRepository) {
         this.tripRepository = tripRepository;
         this.tripLikeRepository = tripLikeRepository;
         this.validationUtil = validationUtil;
@@ -57,6 +61,7 @@ public class TripService {
         this.cityRepository = cityRepository;
         this.itineraryRepository = itineraryRepository;
         this.reservationRepository = reservationRepository;
+        this.tripParticipantRepository = tripParticipantRepository;
     }
 
     /**
@@ -151,7 +156,12 @@ public class TripService {
                 throw new BadRequestExceptionMessage("비공개 여행 계획입니다. 로그인 필요");
             }
             User currentUser = validationUtil.validateUserExists(userEmail);
-            if (!trip.getUser().getUserId().equals(currentUser.getUserId())) {
+            boolean isMyPlan = trip.getUser().getUserId().equals(currentUser.getUserId());
+            Optional<TripParticipant> isFriendsPlan = tripParticipantRepository.findByTrip_TripIdAndParticipant_UserId(tripId, currentUser.getUserId());
+            boolean isAdmin = validationUtil.validateUserIsAdmin(currentUser);
+            boolean isStaff = validationUtil.validateUserIsStaff(currentUser);
+            if (!(isAdmin || isStaff) // 1. 관리자가 아닌 일반 유저는
+            && !isMyPlan && isFriendsPlan.isEmpty()) { // 2. 본인 것도 아니면서 친구 것도 아닌 비공개 여행 계획은 접근 불가
                 throw new BadRequestExceptionMessage("비공개 여행 계획 접근 불가");
             }
         }

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -90,6 +90,10 @@ public class ValidationUtil {
         return "ADMIN".equals(user.getRoleEnum().name());
     }
 
+    public Boolean validateUserIsStaff(User user) {
+        return "STAFF".equals(user.getRoleEnum().name());
+    }
+
     /* ==========================
        2) 커뮤니티(게시글) 관련 검증
        ========================== */


### PR DESCRIPTION
## 작업 내용
- 타인의 비공개 플랜이어도 동반자라면 여행 계획을 조회할 수 있도록 수정
- 스태프도 관리자와 동일하게 비공개를 포함한 전체 여행게획을 조회할 수 있도록 수정
- 관리자만 수행할 수 있던 기능(공지사항 crud, 배너 crud)을 스텝도 가능하게 수정

## 전달사항
- 스텝은 이제 웬만한 기능은 다 수행가능하고, 유저 권한 변경과 유저 강퇴만 관리자 고유의 기능으로 남겨두었습니다