### PR TITLE
게시판 관련 추가사항 반영, 비공개된 여행플랜 처리

### DIFF
--- a/src/main/java/com/jandi/plan_backend/commu/controller/PostController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/PostController.java
@@ -167,4 +167,13 @@ public class PostController {
                 "items", postsPage.getContent()
         );
     }
+
+    //DEV용: 기존 게시글은 미리보기가 없으니 강제로 넣어줄 목적임
+    @PatchMapping("/patch/preview")
+    @GetMapping("/posts")
+    public ResponseEntity<?> patchPreview(
+    ) {
+        postService.patchPreview();
+        return ResponseEntity.ok(null);
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -20,11 +20,13 @@ public class CommunityListDTO {
     private final Integer commentCount;
     private final Integer viewCount;
     private final String thumbnail;
+    private final String preview;
 
     // 프로필 사진 필요한 버전
     public CommunityListDTO(Community community, ImageService imageService, String thumbnail) {
         this.postId = community.getPostId();
         this.viewCount = community.getViewCount();
+        this.preview = community.getPreview();
         this.user = new UserCommunityDTO(community.getUser(), imageService);
         this.createdAt = community.getCreatedAt();
         this.title = community.getTitle();
@@ -42,6 +44,7 @@ public class CommunityListDTO {
         this.title = community.getTitle();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
+        this.preview = community.getPreview();
         this.thumbnail = null;
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -19,9 +19,10 @@ public class CommunityListDTO {
     private final Integer likeCount;
     private final Integer commentCount;
     private final Integer viewCount;
+    private final String thumbnail;
 
     // 프로필 사진 필요한 버전
-    public CommunityListDTO(Community community, ImageService imageService) {
+    public CommunityListDTO(Community community, ImageService imageService, String thumbnail) {
         this.postId = community.getPostId();
         this.viewCount = community.getViewCount();
         this.user = new UserCommunityDTO(community.getUser(), imageService);
@@ -29,6 +30,7 @@ public class CommunityListDTO {
         this.title = community.getTitle();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
+        this.thumbnail = thumbnail;
     }
 
     // 프로필 사진 필요없는 버전
@@ -40,5 +42,6 @@ public class CommunityListDTO {
         this.title = community.getTitle();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
+        this.thumbnail = null;
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
+++ b/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
@@ -28,6 +28,9 @@ public class Community {
     @Column(columnDefinition = "TEXT")
     private String contents;
 
+    @Column(length = 200, nullable = false)
+    private String preview;
+
     @Column(nullable = false)
     private Integer likeCount;
 

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -43,6 +43,7 @@ public class PostService {
     private final UserRepository userRepository;
     private final CommentReportedRepository commentReportedRepository;
     private final CommentLikeRepository commentLikeRepository;
+    String prefix = "https://storage.googleapis.com/plan-storage/";
 
     // 생성자 주입
     public PostService(
@@ -91,7 +92,13 @@ public class PostService {
         Sort sort = Sort.by(Sort.Direction.DESC, "postId");
         return PaginationService.getPagedData(page, size, totalCount,
                 (pageable) -> communityRepository.findAll(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort)),
-                community -> new CommunityListDTO(community, imageService));
+                community -> {
+                    // 썸네일 찾기
+                    List<Image> thumbnails = imageRepository.findAllByTargetTypeAndTargetId("community", community.getPostId());
+                    String thumbnail = (thumbnails.isEmpty()) ? "" : prefix + thumbnails.get(0).getImageUrl();
+
+                    return new CommunityListDTO(community, imageService, thumbnail);
+                });
     }
 
     /**
@@ -294,7 +301,13 @@ public class PostService {
                     List<Community> pagedList = searchList.subList(start, end);
                     return new PageImpl<>(pagedList, pageable, totalCount);
                 },
-                community -> new CommunityListDTO(community, imageService)
+                community -> {
+                    // 썸네일 찾기
+                    List<Image> thumbnails = imageRepository.findAllByTargetTypeAndTargetId("community", community.getPostId());
+                    String thumbnail = (thumbnails.isEmpty()) ? "" : prefix + thumbnails.get(0).getImageUrl();
+
+                    return new CommunityListDTO(community, imageService, thumbnail);
+                }
         );
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -1,5 +1,8 @@
 package com.jandi.plan_backend.commu.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jandi.plan_backend.commu.dto.*;
 import com.jandi.plan_backend.commu.entity.Comment;
 import com.jandi.plan_backend.commu.entity.Community;
@@ -44,6 +47,7 @@ public class PostService {
     private final CommentReportedRepository commentReportedRepository;
     private final CommentLikeRepository commentLikeRepository;
     String prefix = "https://storage.googleapis.com/plan-storage/";
+    int maxPreviewLength = 200;
 
     // 생성자 주입
     public PostService(
@@ -116,6 +120,7 @@ public class PostService {
         community.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         community.setLikeCount(0);
         community.setCommentCount(0);
+        community.setPreview(getPreview(reqDTO.getContent())); // 미리보기 반영
         communityRepository.save(community);
 
         int realPostId = community.getPostId();
@@ -139,6 +144,7 @@ public class PostService {
 
         post.setTitle(postDTO.getTitle());
         post.setContents(postDTO.getContent());
+        post.setPreview(getPreview(postDTO.getContent())); // 미리보기 반영
         communityRepository.save(post);
 
         // 게시글 수정 후, 사용되지 않는 이미지 삭제
@@ -264,6 +270,49 @@ public class PostService {
                 imageService.deleteImage(image.getImageId());
             }
         }
+    }
+
+    //DEV용: 기존 게시글도 미리보기 내용을 추가하기 위해 작성한 메서드
+    public void patchPreview(){
+        communityRepository.findAll().forEach(community -> {
+            log.info("[현재 게시글] postId: {}", community.getPostId());
+            community.setPreview(getPreview(community.getContents()));
+            communityRepository.save(community);
+        });
+    }
+
+    /**
+     * 엔터는 ""로 치환 후, 최대 200자 길이의 미리보기 내용을 추출합니다.
+     */
+    private String getPreview (String contents) {
+        StringBuilder preview = new StringBuilder();
+        try {
+            // contents를 ObjectMapper로 파싱
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode node = mapper.readTree(contents);
+
+            // contents 의 구조: {"ops":[{"insert":"..."},{"attributes":{"code-block":"plain"},..}
+            // 여기서 실제 추출해야 할 부분은 insert의 값이므로, for문을 돌면서 글자수가 채워질 때까지 insert 안의 내용을 순차적으로 더해갑니다
+            for(JsonNode opsNode : node.get("ops")) {
+                // 남은 preview의 길이 계산해서 공간 없다면
+                int leftLength = maxPreviewLength - preview.length();
+                if(leftLength < 1) break;
+
+                JsonNode insertNode = opsNode.get("insert");
+                if(insertNode != null) {
+                    //원문에서 \n은 ""으로 치환
+                    String insertNodeText = insertNode.asText().replace("\n", "");
+
+                    log.info("선택된 insertNodeText: {}", insertNodeText);
+                    preview.append((insertNodeText.length() > leftLength) ? //넘치면 잘라내기
+                            insertNodeText.substring(0, leftLength) : insertNodeText);
+                }
+            }
+            log.info("최종 preview: {}", preview);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return preview.toString();
     }
 
     public Page<CommunityListDTO> search(String category, String keyword, int page, int size) {

--- a/src/main/java/com/jandi/plan_backend/trip/dto/TripRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/trip/dto/TripRespDTO.java
@@ -32,7 +32,28 @@ public class TripRespDTO {
                        String userProfileUrl,
                        Trip trip,
                        String cityImageUrl) {
-        this(user, userProfileUrl, trip, cityImageUrl, null);
+        this(user, userProfileUrl, trip, cityImageUrl, "");
+    }
+
+    public TripRespDTO(Trip trip, String cityImageUrl) {
+        // 비공개여도 넘겨줄 정보
+        this.tripId = trip.getTripId();
+        this.cityId = trip.getCity().getCityId();
+        this.cityName = trip.getCity().getName();
+        this.countryName = trip.getCity().getCountry().getName();
+        this.latitude = trip.getCity().getLatitude();
+        this.longitude = trip.getCity().getLongitude();
+        this.cityImageUrl = cityImageUrl;
+
+        // 비공개로 인한 마스킹 처리
+        this.user = new UserTripDTO(null, "", "");
+        this.title = "";
+        this.startDate = null;
+        this.endDate = null;
+        this.likeCount = null;
+        this.budget = null;
+        this.privatePlan = true;
+        tripImageUrl = "";
     }
 
     public TripRespDTO(User user,


### PR DESCRIPTION
## 작업 내용
- 비공개된 여행플랜은 기본적인 정보 외에 null, 혹은 ""로 가려서 보내주도록 수정
- 게시글 미리보기 내용 컬럼 추가
- 게시글 썸네일을 함께 내려주도록 수정

## 전달 사항
- 여행 플랜 `Trip`을 비공개 처리해서 `TripRespDTO`로 변환해주는 `convertToPrivateTripRespDTO()` 메서드 추가
- `TripRespDTO`에 비공개 플랜을 위한 별도의 생성자 추가
- 게시글 미리보기와 썸네일을 추가로 내려주기 위해 `CommunityListDTO`에 인자 추가
-> 영향받은 것: 게시글 목록 조회 API, 게시글 검색 API, 게시글 신고 API 반환 형태
- 기존 게시글에도 미리보기 내용을 붙여주기 위해 DEV용 미리보기 내용 업데이트 API 추가 ([/api/community/patch/preview](url))