### PR TITLE
Feat: 해시태그 추가

### DIFF
--- a/src/main/java/com/jandi/plan_backend/commu/controller/PostController.java
+++ b/src/main/java/com/jandi/plan_backend/commu/controller/PostController.java
@@ -167,4 +167,13 @@ public class PostController {
                 "items", postsPage.getContent()
         );
     }
+
+    //DEV용: 기존 게시글은 미리보기가 없으니 강제로 넣어줄 목적임
+    @PatchMapping("/patch/preview")
+    @GetMapping("/posts")
+    public ResponseEntity<?> patchPreview(
+    ) {
+        postService.patchPreview();
+        return ResponseEntity.ok(null);
+    }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -21,7 +21,7 @@ public class CommunityListDTO {
     private final Integer viewCount;
     private final String thumbnail;
     private final String preview;
-    private final String hashtag;
+    private final String[] hashtag;
 
     // 프로필 사진 필요한 버전
     public CommunityListDTO(Community community, ImageService imageService, String thumbnail) {
@@ -34,7 +34,7 @@ public class CommunityListDTO {
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
         this.thumbnail = thumbnail;
-        this.hashtag = community.getHashtag();
+        this.hashtag = community.getHashtags().toArray(new String[0]);
     }
 
     // 프로필 사진 필요없는 버전
@@ -47,7 +47,7 @@ public class CommunityListDTO {
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
         this.preview = community.getPreview();
-        this.hashtag = community.getHashtag();
+        this.hashtag = community.getHashtags().toArray(new String[0]);
         this.thumbnail = "";
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -20,11 +20,13 @@ public class CommunityListDTO {
     private final Integer commentCount;
     private final Integer viewCount;
     private final String thumbnail;
+    private final String preview;
 
     // 프로필 사진 필요한 버전
     public CommunityListDTO(Community community, ImageService imageService, String thumbnail) {
         this.postId = community.getPostId();
         this.viewCount = community.getViewCount();
+        this.preview = community.getPreview();
         this.user = new UserCommunityDTO(community.getUser(), imageService);
         this.createdAt = community.getCreatedAt();
         this.title = community.getTitle();
@@ -42,6 +44,7 @@ public class CommunityListDTO {
         this.title = community.getTitle();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
+        this.preview = community.getPreview();
         this.thumbnail = null;
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -21,6 +21,7 @@ public class CommunityListDTO {
     private final Integer viewCount;
     private final String thumbnail;
     private final String preview;
+    private final String hashtag;
 
     // 프로필 사진 필요한 버전
     public CommunityListDTO(Community community, ImageService imageService, String thumbnail) {
@@ -33,6 +34,7 @@ public class CommunityListDTO {
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
         this.thumbnail = thumbnail;
+        this.hashtag = community.getHashtag();
     }
 
     // 프로필 사진 필요없는 버전
@@ -45,6 +47,7 @@ public class CommunityListDTO {
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
         this.preview = community.getPreview();
-        this.thumbnail = null;
+        this.hashtag = community.getHashtag();
+        this.thumbnail = "";
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityListDTO.java
@@ -19,9 +19,10 @@ public class CommunityListDTO {
     private final Integer likeCount;
     private final Integer commentCount;
     private final Integer viewCount;
+    private final String thumbnail;
 
     // 프로필 사진 필요한 버전
-    public CommunityListDTO(Community community, ImageService imageService) {
+    public CommunityListDTO(Community community, ImageService imageService, String thumbnail) {
         this.postId = community.getPostId();
         this.viewCount = community.getViewCount();
         this.user = new UserCommunityDTO(community.getUser(), imageService);
@@ -29,6 +30,7 @@ public class CommunityListDTO {
         this.title = community.getTitle();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
+        this.thumbnail = thumbnail;
     }
 
     // 프로필 사진 필요없는 버전
@@ -40,5 +42,6 @@ public class CommunityListDTO {
         this.title = community.getTitle();
         this.likeCount = community.getLikeCount();
         this.commentCount = community.getCommentCount();
+        this.thumbnail = null;
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReqDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReqDTO.java
@@ -3,6 +3,8 @@ package com.jandi.plan_backend.commu.dto;
 import lombok.Data;
 import lombok.NonNull;
 
+import java.util.List;
+
 @Data
 public class CommunityReqDTO {
 
@@ -13,5 +15,5 @@ public class CommunityReqDTO {
     private final String content;
 
     @NonNull
-    private final String hashtag;
+    private final List<String> hashtag;
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReqDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityReqDTO.java
@@ -7,8 +7,11 @@ import lombok.NonNull;
 public class CommunityReqDTO {
 
     @NonNull
-    final String title;
+    private final String title;
 
     @NonNull
     private final String content;
+
+    @NonNull
+    private final String hashtag;
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityRespDTO.java
@@ -19,7 +19,7 @@ public class CommunityRespDTO {
     private int likeCount;
     private int commentCount;
     private int viewCount;
-    private String hashtag;
+    private String[] hashtag;
     private UserCommunityDTO user; // 유저 정보 중 민감 정보 제외
 
     public CommunityRespDTO(Community community, ImageService imageService) {
@@ -30,7 +30,7 @@ public class CommunityRespDTO {
         this.content = community.getContents();
         this.likeCount = community.getLikeCount();
         this.viewCount = community.getViewCount();
-        this.hashtag = community.getHashtag();
+        this.hashtag = community.getHashtags().toArray(new String[0]);
         this.commentCount = community.getCommentCount();
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/CommunityRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/CommunityRespDTO.java
@@ -19,6 +19,7 @@ public class CommunityRespDTO {
     private int likeCount;
     private int commentCount;
     private int viewCount;
+    private String hashtag;
     private UserCommunityDTO user; // 유저 정보 중 민감 정보 제외
 
     public CommunityRespDTO(Community community, ImageService imageService) {
@@ -29,6 +30,7 @@ public class CommunityRespDTO {
         this.content = community.getContents();
         this.likeCount = community.getLikeCount();
         this.viewCount = community.getViewCount();
+        this.hashtag = community.getHashtag();
         this.commentCount = community.getCommentCount();
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/PostFinalizeReqDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/PostFinalizeReqDTO.java
@@ -2,6 +2,8 @@ package com.jandi.plan_backend.commu.dto;
 
 import lombok.Data;
 
+import java.util.List;
+
 /**
  * 임시 postId(음수 int) + 최종 게시글 정보
  */
@@ -10,5 +12,5 @@ public class PostFinalizeReqDTO {
     private int tempPostId;  // 음수 int
     private String title;
     private String content;
-    private String hashtag;
+    private List<String> hashtag;
 }

--- a/src/main/java/com/jandi/plan_backend/commu/dto/PostFinalizeReqDTO.java
+++ b/src/main/java/com/jandi/plan_backend/commu/dto/PostFinalizeReqDTO.java
@@ -10,4 +10,5 @@ public class PostFinalizeReqDTO {
     private int tempPostId;  // 음수 int
     private String title;
     private String content;
+    private String hashtag;
 }

--- a/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
+++ b/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
@@ -31,6 +31,9 @@ public class Community {
     @Column(length = 200, nullable = false)
     private String preview;
 
+    @Column(length = 255, nullable = false)
+    private String hashtag;
+
     @Column(nullable = false)
     private Integer likeCount;
 

--- a/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
+++ b/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
@@ -28,6 +28,9 @@ public class Community {
     @Column(columnDefinition = "TEXT")
     private String contents;
 
+    @Column(length = 200, nullable = false)
+    private String preview;
+
     @Column(nullable = false)
     private Integer likeCount;
 

--- a/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
+++ b/src/main/java/com/jandi/plan_backend/commu/entity/Community.java
@@ -31,8 +31,9 @@ public class Community {
     @Column(length = 200, nullable = false)
     private String preview;
 
-    @Column(length = 255, nullable = false)
-    private String hashtag;
+    @Convert(converter = CommunityHashtagConverter.class)
+    @Column(columnDefinition = "JSON")
+    private List<String> hashtags;
 
     @Column(nullable = false)
     private Integer likeCount;
@@ -46,3 +47,4 @@ public class Community {
     @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments;
 }
+

--- a/src/main/java/com/jandi/plan_backend/commu/entity/CommunityHashtagConverter.java
+++ b/src/main/java/com/jandi/plan_backend/commu/entity/CommunityHashtagConverter.java
@@ -1,0 +1,36 @@
+package com.jandi.plan_backend.commu.entity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Converter
+public class CommunityHashtagConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) return "[]";
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to convert List<String> to JSON", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) return Collections.emptyList();
+        try {
+            return objectMapper.readValue(dbData, objectMapper.getTypeFactory().constructCollectionType(List.class, String.class));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to convert JSON to List<String>", e);
+        }
+    }
+}

--- a/src/main/java/com/jandi/plan_backend/commu/repository/CommunityRepository.java
+++ b/src/main/java/com/jandi/plan_backend/commu/repository/CommunityRepository.java
@@ -27,4 +27,6 @@ public interface CommunityRepository extends JpaRepository<Community, Integer> {
     List<Community> searchByTitleAndContents(String keyword);
 
     List<Community> findByUser(User user);
+
+    List<Community> searchAllByHashtagContaining(String keyword);
 }

--- a/src/main/java/com/jandi/plan_backend/commu/repository/CommunityRepository.java
+++ b/src/main/java/com/jandi/plan_backend/commu/repository/CommunityRepository.java
@@ -4,6 +4,7 @@ import com.jandi.plan_backend.commu.entity.Community;
 import com.jandi.plan_backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -28,5 +29,7 @@ public interface CommunityRepository extends JpaRepository<Community, Integer> {
 
     List<Community> findByUser(User user);
 
-    List<Community> searchAllByHashtagContaining(String keyword);
+    //해시태그로 검색: JSON 형태로 검색
+    @Query(value = "SELECT * FROM community WHERE JSON_CONTAINS(hashtags, :jsonTag)", nativeQuery = true)
+    List<Community> searchByHashTag(@Param("jsonTag") String keyword);
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -122,7 +122,7 @@ public class PostService {
         community.setLikeCount(0);
         community.setCommentCount(0);
         community.setPreview(getPreview(reqDTO.getContent())); // 미리보기 반영
-        community.setHashtag(reqDTO.getHashtag()); //해시태그 반영
+        community.setHashtags(reqDTO.getHashtag()); //해시태그 반영
         communityRepository.save(community);
 
         int realPostId = community.getPostId();
@@ -149,7 +149,7 @@ public class PostService {
         post.setTitle(postDTO.getTitle());
         post.setContents(postDTO.getContent());
         post.setPreview(getPreview(postDTO.getContent())); // 미리보기 반영
-        post.setHashtag(postDTO.getHashtag()); // 해시태그 반영
+        post.setHashtags(postDTO.getHashtag()); // 해시태그 반영
         communityRepository.save(post);
 
         // 게시글 수정 후, 사용되지 않는 이미지 삭제
@@ -342,7 +342,7 @@ public class PostService {
             case "BOTH" -> // 제목 + 내용 검색
                 communityRepository.searchByTitleAndContents("\"" + keyword + "\""); //공백 포함하여 계산되도록 따옴표로 래핑
             case "HASHTAG" -> // 해시태그 검색
-                communityRepository.searchAllByHashtagContaining("#"+keyword+" ");
+                communityRepository.searchByHashTag("\"" + keyword + "\"");
             default ->
                 throw new IllegalStateException("카테고리 지정이 잘못되었습니다: " + category);
         };

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -43,6 +43,7 @@ public class PostService {
     private final UserRepository userRepository;
     private final CommentReportedRepository commentReportedRepository;
     private final CommentLikeRepository commentLikeRepository;
+    String prefix = "https://storage.googleapis.com/plan-storage/";
 
     // 생성자 주입
     public PostService(
@@ -91,7 +92,13 @@ public class PostService {
         Sort sort = Sort.by(Sort.Direction.DESC, "postId");
         return PaginationService.getPagedData(page, size, totalCount,
                 (pageable) -> communityRepository.findAll(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort)),
-                community -> new CommunityListDTO(community, imageService));
+                community -> {
+                    // 썸네일 찾기
+                    List<Image> thumbnails = imageRepository.findAllByTargetTypeAndTargetId("community", community.getPostId());
+                    String thumbnail = (thumbnails.isEmpty()) ? "" : prefix + thumbnails.get(0).getImageUrl();
+
+                    return new CommunityListDTO(community, imageService, thumbnail);
+                });
     }
 
     /**
@@ -294,7 +301,13 @@ public class PostService {
                     List<Community> pagedList = searchList.subList(start, end);
                     return new PageImpl<>(pagedList, pageable, totalCount);
                 },
-                community -> new CommunityListDTO(community, imageService)
+                community -> {
+                    // 썸네일 찾기
+                    List<Image> thumbnails = imageRepository.findAllByTargetTypeAndTargetId("community", community.getPostId());
+                    String thumbnail = (thumbnails.isEmpty()) ? "" : prefix + thumbnails.get(0).getImageUrl();
+
+                    return new CommunityListDTO(community, imageService, thumbnail);
+                }
         );
     }
 }

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -111,6 +111,7 @@ public class PostService {
     public CommunityRespDTO finalizePost(String userEmail, PostFinalizeReqDTO reqDTO) {
         User user = validationUtil.validateUserExists(userEmail);
         validationUtil.validateUserRestricted(user);
+        validationUtil.validateIsHashtagValid(reqDTO.getHashtag());
         inMemoryTempPostService.validateTempId(reqDTO.getTempPostId(), user.getUserId());
 
         Community community = new Community();
@@ -121,6 +122,7 @@ public class PostService {
         community.setLikeCount(0);
         community.setCommentCount(0);
         community.setPreview(getPreview(reqDTO.getContent())); // 미리보기 반영
+        community.setHashtag(reqDTO.getHashtag()); //해시태그 반영
         communityRepository.save(community);
 
         int realPostId = community.getPostId();
@@ -141,10 +143,13 @@ public class PostService {
         User user = validationUtil.validateUserExists(userEmail);
         validationUtil.validateUserRestricted(user);
         validationUtil.validateUserIsAuthorOfPost(user, post);
+        validationUtil.validateIsHashtagValid(postDTO.getHashtag());
+
 
         post.setTitle(postDTO.getTitle());
         post.setContents(postDTO.getContent());
         post.setPreview(getPreview(postDTO.getContent())); // 미리보기 반영
+        post.setHashtag(postDTO.getHashtag()); // 해시태그 반영
         communityRepository.save(post);
 
         // 게시글 수정 후, 사용되지 않는 이미지 삭제

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -1,5 +1,8 @@
 package com.jandi.plan_backend.commu.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jandi.plan_backend.commu.dto.*;
 import com.jandi.plan_backend.commu.entity.Comment;
 import com.jandi.plan_backend.commu.entity.Community;
@@ -44,6 +47,7 @@ public class PostService {
     private final CommentReportedRepository commentReportedRepository;
     private final CommentLikeRepository commentLikeRepository;
     String prefix = "https://storage.googleapis.com/plan-storage/";
+    int maxPreviewLength = 200;
 
     // 생성자 주입
     public PostService(
@@ -116,6 +120,7 @@ public class PostService {
         community.setCreatedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         community.setLikeCount(0);
         community.setCommentCount(0);
+        community.setPreview(getPreview(reqDTO.getContent())); // 미리보기 반영
         communityRepository.save(community);
 
         int realPostId = community.getPostId();
@@ -139,6 +144,7 @@ public class PostService {
 
         post.setTitle(postDTO.getTitle());
         post.setContents(postDTO.getContent());
+        post.setPreview(getPreview(postDTO.getContent())); // 미리보기 반영
         communityRepository.save(post);
 
         // 게시글 수정 후, 사용되지 않는 이미지 삭제
@@ -264,6 +270,49 @@ public class PostService {
                 imageService.deleteImage(image.getImageId());
             }
         }
+    }
+
+    //DEV용: 기존 게시글도 미리보기 내용을 추가하기 위해 작성한 메서드
+    public void patchPreview(){
+        communityRepository.findAll().forEach(community -> {
+            log.info("[현재 게시글] postId: {}", community.getPostId());
+            community.setPreview(getPreview(community.getContents()));
+            communityRepository.save(community);
+        });
+    }
+
+    /**
+     * 엔터는 ""로 치환 후, 최대 200자 길이의 미리보기 내용을 추출합니다.
+     */
+    private String getPreview (String contents) {
+        StringBuilder preview = new StringBuilder();
+        try {
+            // contents를 ObjectMapper로 파싱
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode node = mapper.readTree(contents);
+
+            // contents 의 구조: {"ops":[{"insert":"..."},{"attributes":{"code-block":"plain"},..}
+            // 여기서 실제 추출해야 할 부분은 insert의 값이므로, for문을 돌면서 글자수가 채워질 때까지 insert 안의 내용을 순차적으로 더해갑니다
+            for(JsonNode opsNode : node.get("ops")) {
+                // 남은 preview의 길이 계산해서 공간 없다면
+                int leftLength = maxPreviewLength - preview.length();
+                if(leftLength < 1) break;
+
+                JsonNode insertNode = opsNode.get("insert");
+                if(insertNode != null) {
+                    //원문에서 \n은 ""으로 치환
+                    String insertNodeText = insertNode.asText().replace("\n", "");
+
+                    log.info("선택된 insertNodeText: {}", insertNodeText);
+                    preview.append((insertNodeText.length() > leftLength) ? //넘치면 잘라내기
+                            insertNodeText.substring(0, leftLength) : insertNodeText);
+                }
+            }
+            log.info("최종 preview: {}", preview);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return preview.toString();
     }
 
     public Page<CommunityListDTO> search(String category, String keyword, int page, int size) {

--- a/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
+++ b/src/main/java/com/jandi/plan_backend/commu/service/PostService.java
@@ -341,6 +341,8 @@ public class PostService {
                 communityRepository.searchAllByContentsContaining(keyword);
             case "BOTH" -> // 제목 + 내용 검색
                 communityRepository.searchByTitleAndContents("\"" + keyword + "\""); //공백 포함하여 계산되도록 따옴표로 래핑
+            case "HASHTAG" -> // 해시태그 검색
+                communityRepository.searchAllByHashtagContaining("#"+keyword+" ");
             default ->
                 throw new IllegalStateException("카테고리 지정이 잘못되었습니다: " + category);
         };

--- a/src/main/java/com/jandi/plan_backend/trip/dto/TripRespDTO.java
+++ b/src/main/java/com/jandi/plan_backend/trip/dto/TripRespDTO.java
@@ -32,7 +32,28 @@ public class TripRespDTO {
                        String userProfileUrl,
                        Trip trip,
                        String cityImageUrl) {
-        this(user, userProfileUrl, trip, cityImageUrl, null);
+        this(user, userProfileUrl, trip, cityImageUrl, "");
+    }
+
+    public TripRespDTO(Trip trip, String cityImageUrl) {
+        // 비공개여도 넘겨줄 정보
+        this.tripId = trip.getTripId();
+        this.cityId = trip.getCity().getCityId();
+        this.cityName = trip.getCity().getName();
+        this.countryName = trip.getCity().getCountry().getName();
+        this.latitude = trip.getCity().getLatitude();
+        this.longitude = trip.getCity().getLongitude();
+        this.cityImageUrl = cityImageUrl;
+
+        // 비공개로 인한 마스킹 처리
+        this.user = new UserTripDTO(null, "", "");
+        this.title = "";
+        this.startDate = null;
+        this.endDate = null;
+        this.likeCount = null;
+        this.budget = null;
+        this.privatePlan = true;
+        tripImageUrl = "";
     }
 
     public TripRespDTO(User user,

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -25,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -205,6 +207,27 @@ public class ValidationUtil {
             return LocalDate.parse(date);
         } catch (Exception e) {
             throw new BadRequestExceptionMessage("날짜 형식에 문제가 있습니다. 다시 한번 확인해주세요");
+        }
+    }
+
+    public void validateIsHashtagValid(String request) {
+        // 공백 기준으로 문자열 분할
+        List<String> hashList = Arrays.stream(request.split(" ")).toList();
+        log.info("hashList: {}", hashList.stream());
+
+        // 해시 태그 갯수 검증: 5개 초과하면 에러 반환
+        if(hashList.size() > 5) {
+            throw new BadRequestExceptionMessage("해시태그는 최대 5개만 입력할 수 있습니다");
+        }
+
+        // 각각의 해시태그 검증
+        for (String hashtag : hashList) {
+            if(!hashtag.startsWith("#")){ // #으로 시작하지 않을 때 에러 반환
+                throw new BadRequestExceptionMessage("잘못된 해시태그 입력: " + hashtag);
+            }
+            if(hashtag.length() > 13) { // # 포함 13글자 이상일 때 에러 반환
+                throw new BadRequestExceptionMessage("잘못된 해시태그 입력: " + hashtag);
+            }
         }
     }
 }

--- a/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
+++ b/src/main/java/com/jandi/plan_backend/util/ValidationUtil.java
@@ -210,10 +210,8 @@ public class ValidationUtil {
         }
     }
 
-    public void validateIsHashtagValid(String request) {
-        // 공백 기준으로 문자열 분할
-        List<String> hashList = Arrays.stream(request.split(" ")).toList();
-        log.info("hashList: {}", hashList.stream());
+    public void validateIsHashtagValid(List<String> hashList) {
+        log.info("hashList: {}", (Object) hashList);
 
         // 해시 태그 갯수 검증: 5개 초과하면 에러 반환
         if(hashList.size() > 5) {


### PR DESCRIPTION
## 작업 내용
- 해시태그 컬럼 추가
- 게시글 목록 조회 / 검색 시 해시태그도 같이 내려주도록 수정
- 게시글 생성/수정 시 해시태그도 같이 받게끔 수정

## 전달 사항
- community 테이블에 hashtags 컬럼 추가
-> mysql은 데이터를 배열로 직접 저장하는 대신 JSON 형식으로만 저장하므로, JSON <-> List<String> 변환을 위한 CommunityHashtagConverter.java를 추가함
- validateUtil.java에 해시태그 검증을 위한 메서드 vaildateIsHashtagValid를 추가함
-> 게시글 생성/수정 시 해시태그를 받을 텐데, 이때 받은 해시태그가 형식을 잘 지켰는지 검사하기 위함임
- 해시태그 검색을 위해 postService.search 메서드에 HASHTAG 케이스 추가, CommunityRepository.searchByHashTag 메서드를 추가함